### PR TITLE
Made all tests compatible with R3.6

### DIFF
--- a/tests/testthat/testlogregmulti.R
+++ b/tests/testthat/testlogregmulti.R
@@ -2,6 +2,7 @@ context('logregmulti')
 
 test_that('logregmulti works', {
 
+    suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)
 
     y <- sample(c('A', 'B', 'C'), 100, replace = TRUE)

--- a/tests/testthat/testlogregord.R
+++ b/tests/testthat/testlogregord.R
@@ -2,6 +2,7 @@ context('logregord')
 
 test_that('logregord works', {
 
+    suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)
 
     y <- factor(sample(1:3, 100, replace = TRUE))

--- a/tests/testthat/testmancova.R
+++ b/tests/testthat/testmancova.R
@@ -2,6 +2,7 @@ context('mancova')
 
 test_that('mancova works', {
 
+    suppressWarnings(RNGversion("3.5.0"))
     set.seed(100)
 
     data <- list()


### PR DESCRIPTION
I saw that some tests didn't have the
`suppressWarnings(RNGversion("3.5.0"))` line yet even though they do use
the `sample` function.