### PR TITLE
Changed component(s) to factor(s)

### DIFF
--- a/jamovi/efa.u.yaml
+++ b/jamovi/efa.u.yaml
@@ -61,7 +61,7 @@ children:
                   - name: nFactors
                     type: TextBox
                     label: ''
-                    suffix: component(s)
+                    suffix: factor(s)
                     format: number
                     enable: (nFactorMethod_fixed)
       - type: LayoutBox


### PR DESCRIPTION
Maybe a leftover from the PCA-GUI. To be consistent, it should be factor(s).