### PR TITLE
Changed DESCRIPTIVES to output std.-dev. per default

### DIFF
--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -24,7 +24,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             median = TRUE,
             mode = FALSE,
             sum = FALSE,
-            sd = FALSE,
+            sd = TRUE,
             variance = FALSE,
             range = FALSE,
             min = TRUE,
@@ -130,7 +130,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             private$..sd <- jmvcore::OptionBool$new(
                 "sd",
                 sd,
-                default=FALSE)
+                default=TRUE)
             private$..variance <- jmvcore::OptionBool$new(
                 "variance",
                 variance,
@@ -429,7 +429,7 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param median \code{TRUE} (default) or \code{FALSE}, provide the median
 #' @param mode \code{TRUE} or \code{FALSE} (default), provide the mode
 #' @param sum \code{TRUE} or \code{FALSE} (default), provide the sum
-#' @param sd \code{TRUE} or \code{FALSE} (default), provide the standard
+#' @param sd \code{TRUE} (default) or \code{FALSE}, provide the standard
 #'   deviation
 #' @param variance \code{TRUE} or \code{FALSE} (default), provide the variance
 #' @param range \code{TRUE} or \code{FALSE} (default), provide the range
@@ -478,7 +478,7 @@ descriptives <- function(
     median = TRUE,
     mode = FALSE,
     sum = FALSE,
-    sd = FALSE,
+    sd = TRUE,
     variance = FALSE,
     range = FALSE,
     min = TRUE,

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -235,10 +235,10 @@ options:
     - name: sd
       title: Standard deviation
       type: Bool
-      default: false
+      default: true
       description:
           R: >
-            `TRUE` or `FALSE` (default), provide the standard deviation
+            `TRUE` (default) or `FALSE`, provide the standard deviation
 
     - name: variance
       title: Variance


### PR DESCRIPTION
So far, DESCRIPTIVES per default doesn't output a dispersion measure for continuous data (std. dev. or variance). This default was changed to enable to output std. dev. by default.  