### PR TITLE
added differences in proportions & fisher rxc

### DIFF
--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -465,8 +465,8 @@ contTablesClass <- R6::R6Class(
                         `v[rr]`=rr$rr,
                         `cil[rr]`=rr$lower,
                         `ciu[rr]`=rr$upper))
-                    odds$addFootnote(rowNo=othRowNo, 'v[dp]', paste(self$options$compCols, 'compared'))
-                    odds$addFootnote(rowNo=othRowNo, 'v[rr]', paste(self$options$compCols, 'compared'))
+                    odds$addFootnote(rowNo=othRowNo, 'v[dp]', paste(self$options$compare, 'compared'))
+                    odds$addFootnote(rowNo=othRowNo, 'v[rr]', paste(self$options$compare, 'compared'))
 
                 } else {
                     odds$setRow(rowNo=othRowNo, list(
@@ -602,7 +602,8 @@ contTablesClass <- R6::R6Class(
 
             ciWidth <- self$options$ciWidth / 100
 
-            if (self$options$compCols == "columns") mat <- t(mat)
+            if (self$options$compare == "columns") 
+                mat <- t(mat)
 
             a <- mat[1,1]
             b <- mat[1,2]
@@ -633,7 +634,7 @@ contTablesClass <- R6::R6Class(
             tail <- (100 - ciWidth) / 200
             z <- qnorm(tail, lower.tail = FALSE)
 
-            if (self$options$compCols == "columns") mat <- t(mat)
+            if (self$options$compare == "columns") mat <- t(mat)
 
             a <- mat[1,1]
             b <- mat[1,2]

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -420,11 +420,13 @@ contTablesClass <- R6::R6Class(
 
                 if (is.null(zP))
                     chiSq$addFootnote(rowNo=othRowNo, 'value[zProp]', 'z test only available for 2x2 tables')
+                else
+                    chiSq$addFootnote(rowNo=othRowNo, 'p[zProp]', 'Two sided')
 
                 if (!is.null(fish) & !all(dim(mat) == 2))
                     chiSq$addFootnote(rowNo=othRowNo, 'p[fisher]', 'Hybrid method: χ² if Cochran conditions are met')
-                # if (!is.null(fish))
-                #     chiSq$addFootnote(rowNo=othRowNo, 'p[fisher]', 'Two sided')
+                if (!is.null(fish))
+                    chiSq$addFootnote(rowNo=othRowNo, 'p[fisher]', 'Two sided')
                 
                 values <- list(
                     `v[cont]`=asso$contingency,

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -634,7 +634,8 @@ contTablesClass <- R6::R6Class(
             tail <- (100 - ciWidth) / 200
             z <- qnorm(tail, lower.tail = FALSE)
 
-            if (self$options$compare == "columns") mat <- t(mat)
+            if (self$options$compare == "columns") 
+                mat <- t(mat)
 
             a <- mat[1,1]
             b <- mat[1,2]

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -23,7 +23,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             relRisk = FALSE,
             ci = TRUE,
             ciWidth = 95,
-            compCols = "rows",
+            compare = "rows",
             gamma = FALSE,
             taub = FALSE,
             obs = TRUE,
@@ -122,11 +122,11 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 min=50,
                 max=99.9,
                 default=95)
-            private$..compCols <- jmvcore::OptionBool$new(
-                "compCols",
-                compCols,
-                options=list("rows","columns"
-                default="rows")
+            private$..compare <- jmvcore::OptionList$new(
+                "compare",
+                compare,
+                options=list("rows","columns",
+                default="rows"))
             private$..gamma <- jmvcore::OptionBool$new(
                 "gamma",
                 gamma,
@@ -173,7 +173,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..relRisk)
             self$.addOption(private$..ci)
             self$.addOption(private$..ciWidth)
-            self$.addOption(private$..compCols)
+            self$.addOption(private$..compare)
             self$.addOption(private$..gamma)
             self$.addOption(private$..taub)
             self$.addOption(private$..obs)
@@ -200,7 +200,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         relRisk = function() private$..relRisk$value,
         ci = function() private$..ci$value,
         ciWidth = function() private$..ciWidth$value,
-        compCols = function() private$..compCols$value,
+        compare = function() private$..compare$value,
         gamma = function() private$..gamma$value,
         taub = function() private$..taub$value,
         obs = function() private$..obs$value,
@@ -226,7 +226,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..relRisk = NA,
         ..ci = NA,
         ..ciWidth = NA,
-        ..compCols = NA,
+        ..compare = NA,
         ..gamma = NA,
         ..taub = NA,
         ..obs = NA,
@@ -392,7 +392,7 @@ contTablesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                     "counts",
                     "layers",
                     "ciWidth",
-                    "compCols"),
+                    "compare"),
                 columns=list(
                     list(
                         `name`="t[dp]", 
@@ -657,7 +657,7 @@ contTablesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #'   intervals for the comparative measures
 #' @param ciWidth a number between 50 and 99.9 (default: 95), width of the
 #'   confidence intervals to provide
-#' @param compCols \code{columns} or \code{rows} (default), compare rows/columns in
+#' @param compare \code{columns} or \code{rows} (default), compare rows/columns in
 #'   difference of proportions or relative risks (2x2 tables)
 #' @param gamma \code{TRUE} or \code{FALSE} (default), provide gamma
 #' @param taub \code{TRUE} or \code{FALSE} (default), provide Kendall's tau-b
@@ -707,7 +707,7 @@ contTables <- function(
     relRisk = FALSE,
     ci = TRUE,
     ciWidth = 95,
-    compCols = "rows",
+    compare = "rows",
     gamma = FALSE,
     taub = FALSE,
     obs = TRUE,
@@ -785,7 +785,7 @@ contTables <- function(
         relRisk = relRisk,
         ci = ci,
         ciWidth = ciWidth,
-        compCols = compCols,
+        compare = compare,
         gamma = gamma,
         taub = taub,
         obs = obs,

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -125,8 +125,8 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             private$..compare <- jmvcore::OptionList$new(
                 "compare",
                 compare,
-                options=list("rows","columns",
-                default="rows"))
+                options=list("rows","columns"),
+                default="rows")
             private$..gamma <- jmvcore::OptionBool$new(
                 "gamma",
                 gamma,

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -12,15 +12,18 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             layers = NULL,
             chiSq = TRUE,
             chiSqCorr = FALSE,
+            zProp = FALSE,
             likeRat = FALSE,
             fisher = FALSE,
             contCoef = FALSE,
             phiCra = FALSE,
+            diffProp = FALSE,
             logOdds = FALSE,
             odds = FALSE,
             relRisk = FALSE,
             ci = TRUE,
             ciWidth = 95,
+            compCols = "rows",
             gamma = FALSE,
             taub = FALSE,
             obs = TRUE,
@@ -73,6 +76,10 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "chiSqCorr",
                 chiSqCorr,
                 default=FALSE)
+            private$..zProp <- jmvcore::OptionBool$new(
+                "zProp",
+                zProp,
+                default=FALSE)
             private$..likeRat <- jmvcore::OptionBool$new(
                 "likeRat",
                 likeRat,
@@ -88,6 +95,10 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             private$..phiCra <- jmvcore::OptionBool$new(
                 "phiCra",
                 phiCra,
+                default=FALSE)
+            private$..diffProp <- jmvcore::OptionBool$new(
+                "diffProp",
+                diffProp,
                 default=FALSE)
             private$..logOdds <- jmvcore::OptionBool$new(
                 "logOdds",
@@ -111,6 +122,11 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 min=50,
                 max=99.9,
                 default=95)
+            private$..compCols <- jmvcore::OptionBool$new(
+                "compCols",
+                compCols,
+                options=list("rows","columns"
+                default="rows")
             private$..gamma <- jmvcore::OptionBool$new(
                 "gamma",
                 gamma,
@@ -146,15 +162,18 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..layers)
             self$.addOption(private$..chiSq)
             self$.addOption(private$..chiSqCorr)
+            self$.addOption(private$..zProp)
             self$.addOption(private$..likeRat)
             self$.addOption(private$..fisher)
             self$.addOption(private$..contCoef)
             self$.addOption(private$..phiCra)
+            self$.addOption(private$..diffProp)
             self$.addOption(private$..logOdds)
             self$.addOption(private$..odds)
             self$.addOption(private$..relRisk)
             self$.addOption(private$..ci)
             self$.addOption(private$..ciWidth)
+            self$.addOption(private$..compCols)
             self$.addOption(private$..gamma)
             self$.addOption(private$..taub)
             self$.addOption(private$..obs)
@@ -170,15 +189,18 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         layers = function() private$..layers$value,
         chiSq = function() private$..chiSq$value,
         chiSqCorr = function() private$..chiSqCorr$value,
+        zProp = function() private$..zProp$value,
         likeRat = function() private$..likeRat$value,
         fisher = function() private$..fisher$value,
         contCoef = function() private$..contCoef$value,
         phiCra = function() private$..phiCra$value,
+        diffProp = function() private$..diffProp$value,
         logOdds = function() private$..logOdds$value,
         odds = function() private$..odds$value,
         relRisk = function() private$..relRisk$value,
         ci = function() private$..ci$value,
         ciWidth = function() private$..ciWidth$value,
+        compCols = function() private$..compCols$value,
         gamma = function() private$..gamma$value,
         taub = function() private$..taub$value,
         obs = function() private$..obs$value,
@@ -193,15 +215,18 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..layers = NA,
         ..chiSq = NA,
         ..chiSqCorr = NA,
+        ..zProp = NA,
         ..likeRat = NA,
         ..fisher = NA,
         ..contCoef = NA,
         ..phiCra = NA,
+        ..diffProp = NA,
         ..logOdds = NA,
         ..odds = NA,
         ..relRisk = NA,
         ..ci = NA,
         ..ciWidth = NA,
+        ..compCols = NA,
         ..gamma = NA,
         ..taub = NA,
         ..obs = NA,
@@ -290,6 +315,26 @@ contTablesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                         `format`="zto,pvalue", 
                         `visible`="(chiSqCorr)"),
                     list(
+                        `name`="test[zProp]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="z test for difference proportions", 
+                        `visible`="(zProp)"),
+                    list(
+                        `name`="value[zProp]", 
+                        `title`="Value", 
+                        `visible`="(zProp)"),
+                    list(
+                        `name`="df[zProp]", 
+                        `title`="df", 
+                        `visible`="(zProp)"),
+                    list(
+                        `name`="p[zProp]", 
+                        `title`="p", 
+                        `type`="number", 
+                        `format`="zto,pvalue", 
+                        `visible`="(zProp)"),
+                    list(
                         `name`="test[likeRat]", 
                         `title`="", 
                         `type`="text", 
@@ -340,14 +385,35 @@ contTablesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="odds",
                 title="Comparative Measures",
-                visible="(logOdds || odds || relRisk)",
+                visible="(diffProp || logOdds || odds || relRisk)",
                 clearWith=list(
                     "rows",
                     "cols",
                     "counts",
                     "layers",
-                    "ciWidth"),
+                    "ciWidth",
+                    "compCols"),
                 columns=list(
+                    list(
+                        `name`="t[dp]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="Difference in proportions", 
+                        `visible`="(diffProp)"),
+                    list(
+                        `name`="v[dp]", 
+                        `title`="Value", 
+                        `visible`="(diffProp)"),
+                    list(
+                        `name`="cil[dp]", 
+                        `title`="Lower", 
+                        `superTitle`="Confidence Intervals", 
+                        `visible`="(diffProp && ci)"),
+                    list(
+                        `name`="ciu[dp]", 
+                        `title`="Upper", 
+                        `superTitle`="Confidence Intervals", 
+                        `visible`="(diffProp && ci)"),
                     list(
                         `name`="t[lo]", 
                         `title`="", 
@@ -569,6 +635,8 @@ contTablesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param chiSq \code{TRUE} (default) or \code{FALSE}, provide X²
 #' @param chiSqCorr \code{TRUE} or \code{FALSE} (default), provide X² with
 #'   continuity correction
+#' @param zProp \code{TRUE} or \code{FALSE} (default), provide a z Test for
+#'   differences in proportions
 #' @param likeRat \code{TRUE} or \code{FALSE} (default), provide the
 #'   likelihood ratio
 #' @param fisher \code{TRUE} or \code{FALSE} (default), provide Fisher's exact
@@ -577,6 +645,8 @@ contTablesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #'   contingency coefficient
 #' @param phiCra \code{TRUE} or \code{FALSE} (default), provide Phi and
 #'   Cramer's V
+#' @param diffProp \code{TRUE} or \code{FALSE} (default), provide the
+#'   differences in proportions (only available for 2x2 tables)
 #' @param logOdds \code{TRUE} or \code{FALSE} (default), provide the log odds
 #'   ratio (only available for 2x2 tables)
 #' @param odds \code{TRUE} or \code{FALSE} (default), provide the odds ratio
@@ -587,6 +657,8 @@ contTablesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #'   intervals for the comparative measures
 #' @param ciWidth a number between 50 and 99.9 (default: 95), width of the
 #'   confidence intervals to provide
+#' @param compCols \code{columns} or \code{rows} (default), compare rows/columns in
+#'   difference of proportions or relative risks (2x2 tables)
 #' @param gamma \code{TRUE} or \code{FALSE} (default), provide gamma
 #' @param taub \code{TRUE} or \code{FALSE} (default), provide Kendall's tau-b
 #' @param obs \code{TRUE} or \code{FALSE} (default), provide the observed
@@ -624,15 +696,18 @@ contTables <- function(
     layers = NULL,
     chiSq = TRUE,
     chiSqCorr = FALSE,
+    zProp = FALSE,
     likeRat = FALSE,
     fisher = FALSE,
     contCoef = FALSE,
     phiCra = FALSE,
+    diffProp = FALSE,
     logOdds = FALSE,
     odds = FALSE,
     relRisk = FALSE,
     ci = TRUE,
     ciWidth = 95,
+    compCols = "rows",
     gamma = FALSE,
     taub = FALSE,
     obs = TRUE,
@@ -699,15 +774,18 @@ contTables <- function(
         layers = layers,
         chiSq = chiSq,
         chiSqCorr = chiSqCorr,
+        zProp = zProp,
         likeRat = likeRat,
         fisher = fisher,
         contCoef = contCoef,
         phiCra = phiCra,
+        diffProp = diffProp,
         logOdds = logOdds,
         odds = odds,
         relRisk = relRisk,
         ci = ci,
         ciWidth = ciWidth,
+        compCols = compCols,
         gamma = gamma,
         taub = taub,
         obs = obs,

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -145,6 +145,14 @@ options:
           R: >
             `TRUE` or `FALSE` (default), provide χ² with continuity correction
 
+    - name: zProp
+      title: z test for difference in proportions
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide a z Test for differences in proportions
+
     - name: likeRat
       title: Likelihood ratio
       type: Bool
@@ -176,6 +184,15 @@ options:
       description:
           R: >
             `TRUE` or `FALSE` (default), provide Phi and Cramer's V
+
+    - name: diffProp
+      title: Difference in proportions
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide the differences in proportions (only available
+            for 2x2 tables)
 
     - name: logOdds
       title: Log odds ratio
@@ -223,6 +240,20 @@ options:
           R: >
             a number between 50 and 99.9 (default: 95), width of the confidence
             intervals to provide
+
+    - name: compCols
+      title: Compare
+      type: List
+      options:
+        - title: rows
+          name: rows
+        - title: columns
+          name: columns
+      default: rows
+      description:
+          R: >
+            `columns` or `rows` (default), compare columns/rows in difference of proportions
+            or relative risks (2x2 tables)
 
     - name: gamma
       title: Gamma

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -151,7 +151,7 @@ options:
       default: false
       description:
           R: >
-            `TRUE` or `FALSE` (default), provide a z Test for differences in proportions
+            `TRUE` or `FALSE` (default), provide a z test for differences in proportions
 
     - name: likeRat
       title: Likelihood ratio

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -241,8 +241,8 @@ options:
             a number between 50 and 99.9 (default: 95), width of the confidence
             intervals to provide
 
-    - name: compCols
-      title: Compare
+    - name: compare
+      title: compare
       type: List
       options:
         - title: rows

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -148,7 +148,7 @@ items:
         - counts
         - layers
         - ciWidth
-        - compCols
+        - compare
 
       columns:
         - name: t[dp]

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -69,6 +69,26 @@ items:
           format: zto,pvalue
           visible: (chiSqCorr)
 
+        - name: test[zProp]
+          title: ''
+          type: text
+          content: z test for difference proportions
+          visible: (zProp)
+
+        - name: value[zProp]
+          title: Value
+          visible: (zProp)
+
+        - name: df[zProp]
+          title: df
+          visible: (zProp)
+
+        - name: p[zProp]
+          title: p
+          type: number
+          format: zto,pvalue
+          visible: (zProp)
+
         - name: test[likeRat]
           title: ''
           type: text
@@ -120,7 +140,7 @@ items:
       title: Comparative Measures
       type: Table
       description: a table of comparative measures
-      visible: (logOdds || odds || relRisk)
+      visible: (diffProp || logOdds || odds || relRisk)
 
       clearWith:
         - rows
@@ -128,8 +148,29 @@ items:
         - counts
         - layers
         - ciWidth
+        - compCols
 
       columns:
+        - name: t[dp]
+          title: ''
+          type: text
+          content: Difference in proportions
+          visible: (diffProp)
+
+        - name: v[dp]
+          title: Value
+          visible: (diffProp)
+
+        - name: cil[dp]
+          title: Lower
+          superTitle: Confidence Intervals
+          visible: (diffProp && ci)
+
+        - name: ciu[dp]
+          title: Upper
+          superTitle: Confidence Intervals
+          visible: (diffProp && ci)
+
         - name: t[lo]
           title: ''
           type: text

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -93,7 +93,7 @@ children:
                             format: number
                             enable: (ci)
                       - type: ComboBox
-                        name: compCols
+                        name: compare
           - type: LayoutBox
             margin: large
             stretchFactor: 1

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -62,6 +62,8 @@ children:
                       - type: CheckBox
                         name: chiSqCorr
                       - type: CheckBox
+                        name: zProp
+                      - type: CheckBox
                         name: likeRat
                       - type: CheckBox
                         name: fisher
@@ -74,6 +76,8 @@ children:
                   - type: Label
                     label: Comparative Measures (2x2 only)
                     children:
+                      - type: CheckBox
+                        name: diffProp
                       - type: CheckBox
                         name: logOdds
                       - type: CheckBox
@@ -88,6 +92,8 @@ children:
                             suffix: '%'
                             format: number
                             enable: (ci)
+                      - type: ComboBox
+                        name: compCols
           - type: LayoutBox
             margin: large
             stretchFactor: 1


### PR DESCRIPTION
Changes to conttables to add differences in proportions estimate, 95%CI and z-test
As requested, I have added a checkbox to select rows/columns to compare relative risks and differences in proportions. 
A footnote has been added with this selection.

Also, the Fisher exact test is performed in any table, with the hybrid option to avoid long calculations if Cochran conditions are met. A footnote indicates that for tables >2x2.
