### PR TITLE
Added one-sided hypothesys to Fisher and DP

### DIFF
--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -405,7 +405,7 @@ contTablesClass <- R6::R6Class(
                         `value[likeRat]`=NaN,
                         `df[likeRat]`='',
                         `p[likeRat]`='',
-                        `value[fisher]`=NaN,
+                        `value[fisher]`='',
                         `p[fisher]`='',
                         `value[N]`=n)
                 } else {

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -411,10 +411,8 @@ contTablesClass <- R6::R6Class(
                 } else {
 
                     if (is.null(fish)) {
-                        fishE <- NaN
                         fishP <- ''
                     } else {
-                        fishE <- fish$estimate
                         fishP <- fish$p.value
                     }
 
@@ -439,7 +437,7 @@ contTablesClass <- R6::R6Class(
                         `value[likeRat]`=asso$chisq_tests['Likelihood Ratio', 'X^2'],
                         `df[likeRat]`=asso$chisq_tests['Likelihood Ratio', 'df'],
                         `p[likeRat]`=asso$chisq_tests['Likelihood Ratio', 'P(> X^2)'],
-                        `value[fisher]`=fishE,
+                        `value[fisher]`='',
                         `p[fisher]`=fishP,
                         `value[N]`=n)
                 }

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -13,6 +13,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             chiSq = TRUE,
             chiSqCorr = FALSE,
             zProp = FALSE,
+            hypothesis = "different",
             likeRat = FALSE,
             fisher = FALSE,
             contCoef = FALSE,
@@ -80,6 +81,14 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "zProp",
                 zProp,
                 default=FALSE)
+            private$..hypothesis <- jmvcore::OptionList$new(
+                "hypothesis",
+                hypothesis,
+                options=list(
+                    "different",
+                    "oneGreater",
+                    "twoGreater"),
+                default="different")
             private$..likeRat <- jmvcore::OptionBool$new(
                 "likeRat",
                 likeRat,
@@ -163,6 +172,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..chiSq)
             self$.addOption(private$..chiSqCorr)
             self$.addOption(private$..zProp)
+            self$.addOption(private$..hypothesis)
             self$.addOption(private$..likeRat)
             self$.addOption(private$..fisher)
             self$.addOption(private$..contCoef)
@@ -190,6 +200,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         chiSq = function() private$..chiSq$value,
         chiSqCorr = function() private$..chiSqCorr$value,
         zProp = function() private$..zProp$value,
+        hypothesis = function() private$..hypothesis$value,
         likeRat = function() private$..likeRat$value,
         fisher = function() private$..fisher$value,
         contCoef = function() private$..contCoef$value,
@@ -216,6 +227,7 @@ contTablesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..chiSq = NA,
         ..chiSqCorr = NA,
         ..zProp = NA,
+        ..hypothesis = NA,
         ..likeRat = NA,
         ..fisher = NA,
         ..contCoef = NA,
@@ -270,6 +282,8 @@ contTablesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                     "rows",
                     "cols",
                     "counts",
+                    "hypothesis",
+                    "compare",
                     "layers"),
                 columns=list(
                     list(
@@ -645,6 +659,10 @@ contTablesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #'   contingency coefficient
 #' @param phiCra \code{TRUE} or \code{FALSE} (default), provide Phi and
 #'   Cramer's V
+#' @param hypothesis \code{'different'} (default), \code{'oneGreater'} or
+#'   \code{'twoGreater'}, the alternative hypothesis; group 1 different to group
+#'   2, group 1 greater than group 2, and group 2 greater than group 1
+#'   respectively
 #' @param diffProp \code{TRUE} or \code{FALSE} (default), provide the
 #'   differences in proportions (only available for 2x2 tables)
 #' @param logOdds \code{TRUE} or \code{FALSE} (default), provide the log odds
@@ -697,6 +715,7 @@ contTables <- function(
     chiSq = TRUE,
     chiSqCorr = FALSE,
     zProp = FALSE,
+    hypothesis = "different",
     likeRat = FALSE,
     fisher = FALSE,
     contCoef = FALSE,
@@ -775,6 +794,7 @@ contTables <- function(
         chiSq = chiSq,
         chiSqCorr = chiSqCorr,
         zProp = zProp,
+        hypothesis = hypothesis,
         likeRat = likeRat,
         fisher = fisher,
         contCoef = contCoef,

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -242,7 +242,7 @@ options:
             intervals to provide
 
     - name: compare
-      title: compare
+      title: Compare
       type: List
       options:
         - title: rows
@@ -254,6 +254,26 @@ options:
           R: >
             `columns` or `rows` (default), compare columns/rows in difference of proportions
             or relative risks (2x2 tables)
+
+    - name: hypothesis
+      title: Alternative hypothesis
+      type: List
+      options:
+        - name: different
+          title: "Group 1 ≠ Group 2"
+        - name: oneGreater
+          title: "Group 1 > Group 2"
+        - name: twoGreater
+          title: "Group 1 < Group 2"
+      default: different
+      description:
+          ui: >
+            the alternative hypothesis.
+          R: >
+            `'different'` (default), `'oneGreater'` or
+            `'twoGreater'`, the alternative hypothesis; group 1 different
+            to group 2, group 1 greater than group 2, and group 2 greater than
+            group 1 respectively
 
     - name: gamma
       title: Gamma

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -146,12 +146,12 @@ options:
             `TRUE` or `FALSE` (default), provide χ² with continuity correction
 
     - name: zProp
-      title: z test for difference in proportions
+      title: z test for difference in 2 proportions
       type: Bool
       default: false
       description:
           R: >
-            `TRUE` or `FALSE` (default), provide a z test for differences in proportions
+            `TRUE` or `FALSE` (default), provide a z test for differences between two proportions
 
     - name: likeRat
       title: Likelihood ratio

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -74,7 +74,7 @@ items:
         - name: test[zProp]
           title: ''
           type: text
-          content: z test for difference proportions
+          content: z test difference in 2 proportions
           visible: (zProp)
 
         - name: value[zProp]
@@ -156,7 +156,7 @@ items:
         - name: t[dp]
           title: ''
           type: text
-          content: Difference in proportions
+          content: Difference in 2 proportions
           visible: (diffProp)
 
         - name: v[dp]

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -25,6 +25,8 @@ items:
         - cols
         - counts
         - layers
+        - hypothesis
+        - compare
 
       columns:
         - name: test[chiSq]

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -67,6 +67,28 @@ children:
                         name: likeRat
                       - type: CheckBox
                         name: fisher
+
+                  - type: Label
+                    label: Hypothesis
+                    children:
+                      - type: RadioButton
+                        name: hypothesis_different
+                        optionName: hypothesis
+                        optionPart: different
+                        label: "Group 1 ≠ Group 2"
+        
+                      - type: RadioButton
+                        name: hypothesis_oneGreater
+                        optionName: hypothesis
+                        optionPart: oneGreater
+                        label: "Group 1 > Group 2"
+        
+                      - type: RadioButton
+                        name: hypothesis_twoGreater
+                        optionName: hypothesis
+                        optionPart: twoGreater
+                        label: "Group 1 < Group 2"
+
               - type: LayoutBox
                 cell:
                   column: 1

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -62,11 +62,11 @@ children:
                       - type: CheckBox
                         name: chiSqCorr
                       - type: CheckBox
-                        name: zProp
-                      - type: CheckBox
                         name: likeRat
                       - type: CheckBox
                         name: fisher
+                      - type: CheckBox
+                        name: zProp
 
                   - type: Label
                     label: Hypothesis
@@ -99,13 +99,13 @@ children:
                     label: Comparative Measures (2x2 only)
                     children:
                       - type: CheckBox
-                        name: diffProp
+                        name: odds
                       - type: CheckBox
                         name: logOdds
                       - type: CheckBox
-                        name: odds
-                      - type: CheckBox
                         name: relRisk
+                      - type: CheckBox
+                        name: diffProp
                       - type: CheckBox
                         name: ci
                         children:


### PR DESCRIPTION
Changes in this version:
- One-sided hypothesis can be selected for Fisher's test and differences in proportions. This applies only to 2x2 tables and have no effect on larger tables
- The Fisher exact test for rxc tables always used the exact method, not the hybrid as before, because I have seen inconsistencies whe testing the hybrid
