### PR TITLE
Percentiles added to descriptives

### DIFF
--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1037,6 +1037,7 @@ descriptivesClass <- R6::R6Class(
                 pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
                 pcValues[pcValues < 0 | pcValues > 1] <- NA 
                 pcValues <- pcValues[!is.na(pcValues)]
+                pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
                 npcValues <- length(pcValues)
 
                 if (npcValues > 0){

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1032,7 +1032,7 @@ descriptivesClass <- R6::R6Class(
             pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
 
             return(pcValues)
-        }
+        },
         .addQuantiles = function() {
 
             if ( self$options$pcEqGr ) {

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1104,8 +1104,9 @@ descriptivesClass <- R6::R6Class(
                 npcValues <- length(pcValues)
 
                 if (self$options$pcVal && npcValues > 0) {
+                    quants <- as.numeric(quantile(column, pcValues))
                     for (i in 1:npcValues)
-                        stats[[paste0('perc', i)]] <- pcValues[i]
+                        stats[[paste0('perc', i)]] <- quants[i]
                 }
 
             } else if (jmvcore::canBeNumeric(column)) {

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1038,12 +1038,12 @@ descriptivesClass <- R6::R6Class(
             pcValues <- pcValues[!is.na(pcValues)]
             npcValues <- length(pcValues)
 
-            if (!self$options$pcVal | npcValues == 0)
+            if (! self$options$pcVal || npcValues == 0)
                 return()       
 
             colArgs <- private$colArgs
 
-            private$colArgs$name <- c(colArgs$name, paste0('quant', 1:npcValues))
+            private$colArgs$name <- c(colArgs$name, paste0('perc', 1:npcValues))
             private$colArgs$title <- c(colArgs$title, paste0(round(pcValues * 100, 2), 'th percentile'))
             private$colArgs$type <- c(colArgs$type, rep('number', npcValues))
             private$colArgs$visible <- c(colArgs$visible, rep("(pcValues)", npcValues))
@@ -1098,6 +1098,16 @@ descriptivesClass <- R6::R6Class(
                         stats[[paste0('quant', i)]] <- quants[i]
                 }
 
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+
+                if (self$options$pcVal && npcValues > 0) {
+                    for (i in 1:npcValues)
+                        stats[[paste0('perc', i)]] <- pcValues[i]
+                }
+
             } else if (jmvcore::canBeNumeric(column)) {
 
                 l <- list(mean=NaN, median=NaN, mode=NaN, sum=NaN, sd=NaN, variance=NaN,
@@ -1108,6 +1118,15 @@ descriptivesClass <- R6::R6Class(
                 if ( ! (self$options$quart && pcNEqGr == 4)) {
                     for (i in 1:(pcNEqGr-1))
                         l[[paste0('quant', i)]] <- NaN
+                }
+
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+                if (! self$options$pcVal || npcValues == 0) {
+                    for (i in 1:npcValues)
+                        l[[paste0('perc', i)]] <- NaN
                 }
 
                 stats <- append(stats, l)
@@ -1122,6 +1141,15 @@ descriptivesClass <- R6::R6Class(
                 if ( ! (self$options$quart && pcNEqGr == 4)) {
                     for (i in 1:(pcNEqGr-1))
                         l[[paste0('quant', i)]] <- ''
+                }
+
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+                if (! self$options$pcVal || npcValues == 0) {
+                    for (i in 1:npcValues)
+                        l[[paste0('perc', i)]] <- ''
                 }
 
                 stats <- append(stats, l)

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1028,7 +1028,7 @@ descriptivesClass <- R6::R6Class(
             if ( is.character(pcValues) )
                 pcValues <- as.numeric(unlist(strsplit(pcValues,",")))
             pcValues <- pcValues / 100
-            pcValues[pcValues < 0 | pcValues > 100] <- NA 
+            pcValues[pcValues < 0 | pcValues > 1] <- NA 
             pcValues <- pcValues[!is.na(pcValues)]
             pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
 
@@ -1048,7 +1048,7 @@ descriptivesClass <- R6::R6Class(
                 private$colArgs$visible <- c(colArgs$visible, rep("(pcEqGr)", pcNEqGr - 1))
             }
 
-            if ( self$options$pcVal ){
+            if ( self$options$pc ){
                 pcValues <- private$.getPcValues()
                 npcValues <- length(pcValues)
 
@@ -1108,7 +1108,7 @@ descriptivesClass <- R6::R6Class(
                         stats[[paste0('quant', i)]] <- quants[i]
                 }
 
-                if ( self$options$pcVal ) {
+                if ( self$options$pc ) {
                     pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
 
@@ -1131,7 +1131,7 @@ descriptivesClass <- R6::R6Class(
                         l[[paste0('quant', i)]] <- NaN
                 }
 
-                if ( self$options$pcVal ) {
+                if ( self$options$pc ) {
                     pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
                     if ( npcValues > 0 ) {
@@ -1154,7 +1154,7 @@ descriptivesClass <- R6::R6Class(
                         l[[paste0('quant', i)]] <- ''
                 }
 
-                if ( self$options$pcVal ) {
+                if ( self$options$pc ) {
                     pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
                     if ( npcValues > 0 ) {

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1016,7 +1016,7 @@ descriptivesClass <- R6::R6Class(
         },
         .addQuantiles = function() {
 
-            pcEQ <- NULL
+            pcEq <- NULL
 
             if ( self$options$pcEqGr ) {
                 pcNEqGr <- self$options$pcNEqGr

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1038,7 +1038,7 @@ descriptivesClass <- R6::R6Class(
             pcValues <- pcValues[!is.na(pcValues)]
             npcValues <- length(pcValues)
 
-            if (npcValues == 0)
+            if (self$options$pcVal && npcValues == 0)
                 return()       
 
             colArgs <- private$colArgs

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1038,7 +1038,7 @@ descriptivesClass <- R6::R6Class(
             pcValues <- pcValues[!is.na(pcValues)]
             npcValues <- length(pcValues)
 
-            if (self$options$pcVal && npcValues == 0)
+            if (!self$options$pcVal | npcValues == 0)
                 return()       
 
             colArgs <- private$colArgs

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1085,6 +1085,7 @@ descriptivesClass <- R6::R6Class(
                 stats[['sww']] <- normw
                 stats[['sw']] <- norm
 
+                pcEq <- NULL                
                 if ( self$options$pcEqGr ) {
                     pcNEqGr <- self$options$pcNEqGr
 
@@ -1099,6 +1100,7 @@ descriptivesClass <- R6::R6Class(
                     pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
                     pcValues[pcValues < 0 | pcValues > 1] <- NA 
                     pcValues <- pcValues[!is.na(pcValues)]
+                    pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
                     npcValues <- length(pcValues)
 
                     if ( npcValues > 0 ) {

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1014,16 +1014,32 @@ descriptivesClass <- R6::R6Class(
             else
                 return(FALSE)
         },
-        .addQuantiles = function() {
+        .getPcValues = function(pcEq) {
+    
+            if ( self$options$pcEqGr ) {
+                pcNEqGr <- self$options$pcNEqGr
+                pcEq <- (1:pcNEqGr / pcNEqGr)[-pcNEqGr]
+                pcEq <- round(pcEq, 4)
+            } else
+                pcEq <- NULL
 
-            pcEq <- NULL
+            pcValues<-self$options$pcValues
+            if ( is.string(pcValues) )
+                pcValues <- as.numeric(unlist(strsplit(,",")))
+            pcValues <- pcValues / 100
+            pcValues[pcValues < 0 | pcValues > 100] <- NA 
+            pcValues <- pcValues[!is.na(pcValues)]
+            pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
+
+            return(pcValues)
+        }
+        .addQuantiles = function() {
 
             if ( self$options$pcEqGr ) {
                 pcNEqGr <- self$options$pcNEqGr
 
                 colArgs <- private$colArgs
                 pcEq <- (1:pcNEqGr / pcNEqGr)[-pcNEqGr]
-                pcEq <- round(pcEq, 4)
  
                 private$colArgs$name <- c(colArgs$name, paste0('quant', 1:(pcNEqGr-1)))
                 private$colArgs$title <- c(colArgs$title, paste0(round(pcEq * 100, 2), 'th percentile'))
@@ -1032,11 +1048,7 @@ descriptivesClass <- R6::R6Class(
             }
 
             if ( self$options$pcVal ){
-
-                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
-                pcValues[pcValues < 0 | pcValues > 1] <- NA 
-                pcValues <- pcValues[!is.na(pcValues)]
-                pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
+                pcValues <- private$.getPcValues()
                 npcValues <- length(pcValues)
 
                 if (npcValues > 0){
@@ -1085,7 +1097,6 @@ descriptivesClass <- R6::R6Class(
                 stats[['sww']] <- normw
                 stats[['sw']] <- norm
 
-                pcEq <- NULL                
                 if ( self$options$pcEqGr ) {
                     pcNEqGr <- self$options$pcNEqGr
 
@@ -1097,10 +1108,7 @@ descriptivesClass <- R6::R6Class(
                 }
 
                 if ( self$options$pcVal ) {
-                    pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
-                    pcValues[pcValues < 0 | pcValues > 1] <- NA 
-                    pcValues <- pcValues[!is.na(pcValues)]
-                    pcValues <- pcValues[ ! (pcValues %in% pcEq) ]
+                    pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
 
                     if ( npcValues > 0 ) {
@@ -1123,9 +1131,7 @@ descriptivesClass <- R6::R6Class(
                 }
 
                 if ( self$options$pcVal ) {
-                    pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
-                    pcValues[pcValues < 0 | pcValues > 1] <- NA 
-                    pcValues <- pcValues[!is.na(pcValues)]
+                    pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
                     if ( npcValues > 0 ) {
                         for (i in 1:npcValues)
@@ -1148,9 +1154,7 @@ descriptivesClass <- R6::R6Class(
                 }
 
                 if ( self$options$pcVal ) {
-                    pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
-                    pcValues[pcValues < 0 | pcValues > 1] <- NA 
-                    pcValues <- pcValues[!is.na(pcValues)]
+                    pcValues <- private$.getPcValues()
                     npcValues <- length(pcValues)
                     if ( npcValues > 0 ) {
                         for (i in 1:npcValues)

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1014,18 +1014,19 @@ descriptivesClass <- R6::R6Class(
             else
                 return(FALSE)
         },
-        .getPcValues = function(pcEq) {
+        .getPcValues = function() {
     
             if ( self$options$pcEqGr ) {
                 pcNEqGr <- self$options$pcNEqGr
                 pcEq <- (1:pcNEqGr / pcNEqGr)[-pcNEqGr]
                 pcEq <- round(pcEq, 4)
-            } else
+            } else {
                 pcEq <- NULL
+            }
 
             pcValues<-self$options$pcValues
             if ( is.character(pcValues) )
-                pcValues <- as.numeric(unlist(strsplit(,",")))
+                pcValues <- as.numeric(unlist(strsplit(pcValues,",")))
             pcValues <- pcValues / 100
             pcValues[pcValues < 0 | pcValues > 100] <- NA 
             pcValues <- pcValues[!is.na(pcValues)]

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -21,6 +21,7 @@ descriptivesClass <- R6::R6Class(
         .init = function() {
 
             private$.addQuantiles()
+            private$.addPercentiles()
             private$.initDescriptivesTable()
 
             if (self$options$freq)
@@ -1028,6 +1029,24 @@ descriptivesClass <- R6::R6Class(
             private$colArgs$title <- c(colArgs$title, paste0(round(pcEq * 100, 2), 'th percentile'))
             private$colArgs$type <- c(colArgs$type, rep('number', pcNEqGr - 1))
             private$colArgs$visible <- c(colArgs$visible, rep("(pcEqGr)", pcNEqGr - 1))
+
+        },
+        .addPercentiles = function() {
+
+            pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+            pcValues[pcValues < 0 | pcValues > 1] <- NA 
+            pcValues <- pcValues[!is.na(pcValues)]
+            npcValues <- length(pcValues)
+
+            if (npcValues == 0)
+                return()       
+
+            colArgs <- private$colArgs
+
+            private$colArgs$name <- c(colArgs$name, paste0('quant', 1:npcValues))
+            private$colArgs$title <- c(colArgs$title, paste0(round(pcValues * 100, 2), 'th percentile'))
+            private$colArgs$type <- c(colArgs$type, rep('number', npcValues))
+            private$colArgs$visible <- c(colArgs$visible, rep("(pcValues)", npcValues))
 
         },
         .computeDesc = function(column) {

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -21,6 +21,7 @@ descriptivesClass <- R6::R6Class(
         .init = function() {
 
             private$.addQuantiles()
+            private$.addPercentiles()
             private$.initDescriptivesTable()
 
             if (self$options$freq)
@@ -1030,6 +1031,24 @@ descriptivesClass <- R6::R6Class(
             private$colArgs$visible <- c(colArgs$visible, rep("(pcEqGr)", pcNEqGr - 1))
 
         },
+        .addPercentiles = function() {
+
+            pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+            pcValues[pcValues < 0 | pcValues > 1] <- NA 
+            pcValues <- pcValues[!is.na(pcValues)]
+            npcValues <- length(pcValues)
+
+            if (! self$options$pcVal || npcValues == 0)
+                return()       
+
+            colArgs <- private$colArgs
+
+            private$colArgs$name <- c(colArgs$name, paste0('perc', 1:npcValues))
+            private$colArgs$title <- c(colArgs$title, paste0(round(pcValues * 100, 2), 'th percentile'))
+            private$colArgs$type <- c(colArgs$type, rep('number', npcValues))
+            private$colArgs$visible <- c(colArgs$visible, rep("(pcValues)", npcValues))
+
+        },
         .computeDesc = function(column) {
 
             stats <- list()
@@ -1079,6 +1098,17 @@ descriptivesClass <- R6::R6Class(
                         stats[[paste0('quant', i)]] <- quants[i]
                 }
 
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+
+                if (self$options$pcVal && npcValues > 0) {
+                    quants <- as.numeric(quantile(column, pcValues))
+                    for (i in 1:npcValues)
+                        stats[[paste0('perc', i)]] <- quants[i]
+                }
+
             } else if (jmvcore::canBeNumeric(column)) {
 
                 l <- list(mean=NaN, median=NaN, mode=NaN, sum=NaN, sd=NaN, variance=NaN,
@@ -1089,6 +1119,15 @@ descriptivesClass <- R6::R6Class(
                 if ( ! (self$options$quart && pcNEqGr == 4)) {
                     for (i in 1:(pcNEqGr-1))
                         l[[paste0('quant', i)]] <- NaN
+                }
+
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+                if (! self$options$pcVal || npcValues == 0) {
+                    for (i in 1:npcValues)
+                        l[[paste0('perc', i)]] <- NaN
                 }
 
                 stats <- append(stats, l)
@@ -1103,6 +1142,15 @@ descriptivesClass <- R6::R6Class(
                 if ( ! (self$options$quart && pcNEqGr == 4)) {
                     for (i in 1:(pcNEqGr-1))
                         l[[paste0('quant', i)]] <- ''
+                }
+
+                pcValues <- as.numeric(unlist(strsplit(self$options$pcValues,",")))
+                pcValues[pcValues < 0 | pcValues > 1] <- NA 
+                pcValues <- pcValues[!is.na(pcValues)]
+                npcValues <- length(pcValues)
+                if (! self$options$pcVal || npcValues == 0) {
+                    for (i in 1:npcValues)
+                        l[[paste0('perc', i)]] <- ''
                 }
 
                 stats <- append(stats, l)

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1024,7 +1024,7 @@ descriptivesClass <- R6::R6Class(
                 pcEq <- NULL
 
             pcValues<-self$options$pcValues
-            if ( is.string(pcValues) )
+            if ( is.character(pcValues) )
                 pcValues <- as.numeric(unlist(strsplit(,",")))
             pcValues <- pcValues / 100
             pcValues[pcValues < 0 | pcValues > 100] <- NA 

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -21,7 +21,6 @@ descriptivesClass <- R6::R6Class(
         .init = function() {
 
             private$.addQuantiles()
-            private$.addPercentiles()
             private$.initDescriptivesTable()
 
             if (self$options$freq)
@@ -1017,20 +1016,20 @@ descriptivesClass <- R6::R6Class(
         },
         .addQuantiles = function() {
 
+            pcEQ <- NULL
+
             if ( self$options$pcEqGr ) {
                 pcNEqGr <- self$options$pcNEqGr
 
                 colArgs <- private$colArgs
                 pcEq <- (1:pcNEqGr / pcNEqGr)[-pcNEqGr]
-
+                pcEq <- round(pcEq, 4)
+ 
                 private$colArgs$name <- c(colArgs$name, paste0('quant', 1:(pcNEqGr-1)))
                 private$colArgs$title <- c(colArgs$title, paste0(round(pcEq * 100, 2), 'th percentile'))
                 private$colArgs$type <- c(colArgs$type, rep('number', pcNEqGr - 1))
                 private$colArgs$visible <- c(colArgs$visible, rep("(pcEqGr)", pcNEqGr - 1))
             }
-
-        },
-        .addPercentiles = function() {
 
             if ( self$options$pcVal ){
 

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -501,7 +501,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pc = FALSE,
-    pcValues = "25,50,75",
+    pcValues = c(25,50,75),
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -33,11 +33,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             skew = FALSE,
             kurt = FALSE,
             sw = FALSE,
-            quart = FALSE,
             pcEqGr = FALSE,
             pcNEqGr = 4,
             pcVal = FALSE,
-            pcValues = "0.05,0.95",
+            pcValues = "0.25,0.5,0.75",
             ...) {
 
             super$initialize(
@@ -166,10 +165,6 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "sw",
                 sw,
                 default=FALSE)
-            private$..quart <- jmvcore::OptionBool$new(
-                "quart",
-                quart,
-                default=FALSE)
             private$..pcEqGr <- jmvcore::OptionBool$new(
                 "pcEqGr",
                 pcEqGr,
@@ -187,7 +182,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             private$..pcValues <- jmvcore::OptionString$new(
                 "pcValues",
                 pcValues,
-                default="0.05,0.95")
+                default="0.25,0.5,0.75")
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -216,7 +211,6 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..skew)
             self$.addOption(private$..kurt)
             self$.addOption(private$..sw)
-            self$.addOption(private$..quart)
             self$.addOption(private$..pcEqGr)
             self$.addOption(private$..pcNEqGr)
             self$.addOption(private$..pcVal)
@@ -250,7 +244,6 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         skew = function() private$..skew$value,
         kurt = function() private$..kurt$value,
         sw = function() private$..sw$value,
-        quart = function() private$..quart$value,
         pcEqGr = function() private$..pcEqGr$value,
         pcNEqGr = function() private$..pcNEqGr$value,
         pcVal = function() private$..pcVal$value,
@@ -283,7 +276,6 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..skew = NA,
         ..kurt = NA,
         ..sw = NA,
-        ..quart = NA,
         ..pcEqGr = NA,
         ..pcNEqGr = NA,
         ..pcVal = NA,
@@ -307,7 +299,7 @@ descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="descriptives",
                 title="Descriptives",
-                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr || pcVal)",
+                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pcVal)",
                 rows=1,
                 clearWith=list(
                     "splitBy",
@@ -457,12 +449,11 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param kurt \code{TRUE} or \code{FALSE} (default), provide the kurtosis
 #' @param sw \code{TRUE} or \code{FALSE} (default), provide Shapiro-Wilk
 #'   p-value
-#' @param quart \code{TRUE} or \code{FALSE} (default), provide quartiles
 #' @param pcEqGr \code{TRUE} or \code{FALSE} (default), provide quantiles
 #' @param pcNEqGr an integer (default: 4) specifying the number of equal
 #'   groups
 #' @param pcVal \code{TRUE} or \code{FALSE} (default), provide percentiles
-#' @param pcValues a comma-sepated list (default: 0.05,0.95) specifying the 
+#' @param pcValues a comma-sepated list (default: 0.25,0.5,0.75) specifying the 
 #'   percentiles
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
@@ -507,11 +498,10 @@ descriptives <- function(
     skew = FALSE,
     kurt = FALSE,
     sw = FALSE,
-    quart = FALSE,
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pcVal = FALSE,
-    pcValues = "0.05,0.95",
+    pcValues = "0.25,0.5,0.75",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))
@@ -570,7 +560,6 @@ descriptives <- function(
         skew = skew,
         kurt = kurt,
         sw = sw,
-        quart = quart,
         pcEqGr = pcEqGr,
         pcNEqGr = pcNEqGr,
         pcVal = pcVal,

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -184,7 +184,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "pcVal",
                 pcVal,
                 default=FALSE)
-            private$..pcValues <- jmvcore::OptionBool$new(
+            private$..pcValues <- jmvcore::OptionString$new(
                 "pcValues",
                 pcValues,
                 default="0.05,0.95")

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -511,7 +511,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pcVal = FALSE,
-    pcVal = "0.05,0.95",
+    pcValues = "0.05,0.95",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -35,7 +35,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             sw = FALSE,
             quart = FALSE,
             pcEqGr = FALSE,
-            pcNEqGr = 4, ...) {
+            pcNEqGr = 4,
+            pcVal = FALSE,
+            pcValues = "0.05,0.95",
+            ...) {
 
             super$initialize(
                 package='jmv',
@@ -177,6 +180,14 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 default=4,
                 min=2,
                 max=10)
+            private$..pcVal <- jmvcore::OptionBool$new(
+                "pcVal",
+                pcVal,
+                default=FALSE)
+            private$..pcValues <- jmvcore::OptionString$new(
+                "pcValues",
+                pcValues,
+                default="0.05,0.95")
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -208,6 +219,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..quart)
             self$.addOption(private$..pcEqGr)
             self$.addOption(private$..pcNEqGr)
+            self$.addOption(private$..pcVal)
+            self$.addOption(private$..pcValues)
         }),
     active = list(
         vars = function() private$..vars$value,
@@ -239,7 +252,9 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         sw = function() private$..sw$value,
         quart = function() private$..quart$value,
         pcEqGr = function() private$..pcEqGr$value,
-        pcNEqGr = function() private$..pcNEqGr$value),
+        pcNEqGr = function() private$..pcNEqGr$value,
+        pcVal = function() private$..pcVal$value,
+        pcValues = function() private$..pcValues$value),
     private = list(
         ..vars = NA,
         ..splitBy = NA,
@@ -270,7 +285,9 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..sw = NA,
         ..quart = NA,
         ..pcEqGr = NA,
-        ..pcNEqGr = NA)
+        ..pcNEqGr = NA,
+        ..pcVal = NA,
+        ..pcValues = NA)
 )
 
 descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
@@ -290,7 +307,7 @@ descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="descriptives",
                 title="Descriptives",
-                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr)",
+                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr || pcVal)",
                 rows=1,
                 clearWith=list(
                     "splitBy",
@@ -444,6 +461,9 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param pcEqGr \code{TRUE} or \code{FALSE} (default), provide quantiles
 #' @param pcNEqGr an integer (default: 4) specifying the number of equal
 #'   groups
+#' @param pcVal \code{TRUE} or \code{FALSE} (default), provide percentiles
+#' @param pcValues a comma-sepated list (default: 0.05,0.95) specifying the 
+#'   percentiles
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
 #' \tabular{llllll}{
@@ -490,6 +510,8 @@ descriptives <- function(
     quart = FALSE,
     pcEqGr = FALSE,
     pcNEqGr = 4,
+    pcVal = FALSE,
+    pcVal = "0.05,0.95",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))
@@ -550,7 +572,9 @@ descriptives <- function(
         sw = sw,
         quart = quart,
         pcEqGr = pcEqGr,
-        pcNEqGr = pcNEqGr)
+        pcNEqGr = pcNEqGr,
+        pcVal = pcVal,
+        pcValues = pcValues)
 
     analysis <- descriptivesClass$new(
         options = options,

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -501,7 +501,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pc = FALSE,
-    pcValues = c(25,50,75),
+    pcValues = "25,50,75",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -36,7 +36,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             pcEqGr = FALSE,
             pcNEqGr = 4,
             pcVal = FALSE,
-            pcValues = c(25,50,75),
+            pcValues = "25,50,75",
             ...) {
 
             super$initialize(
@@ -179,10 +179,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "pcVal",
                 pcVal,
                 default=FALSE)
-            private$..pcValues <- jmvcore::OptionInteger$new(
+            private$..pcValues <- jmvcore::OptionString$new(
                 "pcValues",
                 pcValues,
-                default=c(25,50,75))
+                default="25,50,75")
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -501,7 +501,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pcVal = FALSE,
-    pcValues = c(25,50,75),
+    pcValues = "25,50,75",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -36,7 +36,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             pcEqGr = FALSE,
             pcNEqGr = 4,
             pcVal = FALSE,
-            pcValues = "0.25,0.5,0.75",
+            pcValues = "25,50,75",
             ...) {
 
             super$initialize(
@@ -182,7 +182,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             private$..pcValues <- jmvcore::OptionString$new(
                 "pcValues",
                 pcValues,
-                default="0.25,0.5,0.75")
+                default="25,50,75")
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -453,7 +453,7 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param pcNEqGr an integer (default: 4) specifying the number of equal
 #'   groups
 #' @param pcVal \code{TRUE} or \code{FALSE} (default), provide percentiles
-#' @param pcValues a comma-sepated list (default: 0.25,0.5,0.75) specifying the 
+#' @param pcValues a comma-sepated list (default: 25,50,75) specifying the 
 #'   percentiles
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
@@ -501,7 +501,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pcVal = FALSE,
-    pcValues = "0.25,0.5,0.75",
+    pcValues = "25,50,75",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -35,7 +35,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             sw = FALSE,
             quart = FALSE,
             pcEqGr = FALSE,
-            pcNEqGr = 4, ...) {
+            pcNEqGr = 4,
+            pcVal = FALSE,
+            pcValues = "0.05,0.95",
+            ...) {
 
             super$initialize(
                 package='jmv',
@@ -177,6 +180,14 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 default=4,
                 min=2,
                 max=10)
+            private$..pcVal <- jmvcore::OptionBool$new(
+                "pcVal",
+                pcVal,
+                default=FALSE)
+            private$..pcValues <- jmvcore::OptionBool$new(
+                "pcValues",
+                pcValues,
+                default="0.05,0.95")
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -208,6 +219,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..quart)
             self$.addOption(private$..pcEqGr)
             self$.addOption(private$..pcNEqGr)
+            self$.addOption(private$..pcVal)
+            self$.addOption(private$..pcValues)
         }),
     active = list(
         vars = function() private$..vars$value,
@@ -239,7 +252,9 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         sw = function() private$..sw$value,
         quart = function() private$..quart$value,
         pcEqGr = function() private$..pcEqGr$value,
-        pcNEqGr = function() private$..pcNEqGr$value),
+        pcNEqGr = function() private$..pcNEqGr$value,
+        pcVal = function() private$..pcVal$value,
+        pcValues = function() private$..pcValues$value),
     private = list(
         ..vars = NA,
         ..splitBy = NA,
@@ -270,7 +285,9 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..sw = NA,
         ..quart = NA,
         ..pcEqGr = NA,
-        ..pcNEqGr = NA)
+        ..pcNEqGr = NA,
+        ..pcVal = NA,
+        ..pcValues = NA)
 )
 
 descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
@@ -290,7 +307,7 @@ descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="descriptives",
                 title="Descriptives",
-                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr)",
+                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr || pcVal)",
                 rows=1,
                 clearWith=list(
                     "splitBy",
@@ -444,6 +461,9 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param pcEqGr \code{TRUE} or \code{FALSE} (default), provide quantiles
 #' @param pcNEqGr an integer (default: 4) specifying the number of equal
 #'   groups
+#' @param pcVal \code{TRUE} or \code{FALSE} (default), provide percentiles
+#' @param pcValues a comma-sepated list (default: 0.05,0.95) specifying the 
+#'   percentiles
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
 #' \tabular{llllll}{
@@ -490,6 +510,8 @@ descriptives <- function(
     quart = FALSE,
     pcEqGr = FALSE,
     pcNEqGr = 4,
+    pcVal = FALSE,
+    pcVal = "0.05,0.95",
     formula) {
 
     if ( ! requireNamespace('jmvcore'))
@@ -550,7 +572,9 @@ descriptives <- function(
         sw = sw,
         quart = quart,
         pcEqGr = pcEqGr,
-        pcNEqGr = pcNEqGr)
+        pcNEqGr = pcNEqGr,
+        pcVal = pcVal,
+        pcValues = pcValues)
 
     analysis <- descriptivesClass$new(
         options = options,

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -35,7 +35,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             sw = FALSE,
             pcEqGr = FALSE,
             pcNEqGr = 4,
-            pcVal = FALSE,
+            pc = FALSE,
             pcValues = "25,50,75",
             ...) {
 
@@ -175,9 +175,9 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 default=4,
                 min=2,
                 max=10)
-            private$..pcVal <- jmvcore::OptionBool$new(
-                "pcVal",
-                pcVal,
+            private$..pc <- jmvcore::OptionBool$new(
+                "pc",
+                pc,
                 default=FALSE)
             private$..pcValues <- jmvcore::OptionString$new(
                 "pcValues",
@@ -213,7 +213,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..sw)
             self$.addOption(private$..pcEqGr)
             self$.addOption(private$..pcNEqGr)
-            self$.addOption(private$..pcVal)
+            self$.addOption(private$..pc)
             self$.addOption(private$..pcValues)
         }),
     active = list(
@@ -246,7 +246,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         sw = function() private$..sw$value,
         pcEqGr = function() private$..pcEqGr$value,
         pcNEqGr = function() private$..pcNEqGr$value,
-        pcVal = function() private$..pcVal$value,
+        pc = function() private$..pc$value,
         pcValues = function() private$..pcValues$value),
     private = list(
         ..vars = NA,
@@ -278,7 +278,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..sw = NA,
         ..pcEqGr = NA,
         ..pcNEqGr = NA,
-        ..pcVal = NA,
+        ..pc = NA,
         ..pcValues = NA)
 )
 
@@ -299,7 +299,7 @@ descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="descriptives",
                 title="Descriptives",
-                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pcVal)",
+                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pc)",
                 rows=1,
                 clearWith=list(
                     "splitBy",
@@ -452,7 +452,7 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param pcEqGr \code{TRUE} or \code{FALSE} (default), provide quantiles
 #' @param pcNEqGr an integer (default: 4) specifying the number of equal
 #'   groups
-#' @param pcVal \code{TRUE} or \code{FALSE} (default), provide percentiles
+#' @param pc \code{TRUE} or \code{FALSE} (default), provide percentiles
 #' @param pcValues a comma-sepated list (default: 25,50,75) specifying the 
 #'   percentiles
 #' @param formula (optional) the formula to use, see the examples
@@ -500,7 +500,7 @@ descriptives <- function(
     sw = FALSE,
     pcEqGr = FALSE,
     pcNEqGr = 4,
-    pcVal = FALSE,
+    pc = FALSE,
     pcValues = "25,50,75",
     formula) {
 
@@ -562,7 +562,7 @@ descriptives <- function(
         sw = sw,
         pcEqGr = pcEqGr,
         pcNEqGr = pcNEqGr,
-        pcVal = pcVal,
+        pc = pc,
         pcValues = pcValues)
 
     analysis <- descriptivesClass$new(

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -36,7 +36,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             pcEqGr = FALSE,
             pcNEqGr = 4,
             pcVal = FALSE,
-            pcValues = "25,50,75",
+            pcValues = c(25,50,75),
             ...) {
 
             super$initialize(
@@ -179,10 +179,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "pcVal",
                 pcVal,
                 default=FALSE)
-            private$..pcValues <- jmvcore::OptionString$new(
+            private$..pcValues <- jmvcore::OptionInteger$new(
                 "pcValues",
                 pcValues,
-                default="25,50,75")
+                default=c(25,50,75))
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -501,7 +501,7 @@ descriptives <- function(
     pcEqGr = FALSE,
     pcNEqGr = 4,
     pcVal = FALSE,
-    pcValues = "25,50,75",
+    pcValues = c(25,50,75),
     formula) {
 
     if ( ! requireNamespace('jmvcore'))

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -333,8 +333,8 @@ options:
     - name: pcValues
       title: Percentile values
       type: String
-      default: "0.25,0.5,0.75"
+      default: "25,50,75"
       description:
           R: >
-            a comma-sepated list (default: 0.25,0.5,0.75) specifying the percentiles
+            a comma-sepated list (default: 25,50,75) specifying the percentiles
 ...

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -329,4 +329,20 @@ options:
       description:
           R: >
             an integer (default: 4) specifying the number of equal groups
+
+    - name: pcVal
+      title: Percentile
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide percentiles
+
+    - name: pcValues
+      title: Percentile values
+      type: Text
+      default: "0.05,0.95"
+      description:
+          R: >
+            a comma-sepated list (default: 0.05,0.95) specifying the percentiles
 ...

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -304,14 +304,6 @@ options:
           R: >
             `TRUE` or `FALSE` (default), provide Shapiro-Wilk p-value
 
-    - name: quart
-      title: Quartiles
-      type: Bool
-      default: false
-      description:
-          R: >
-            `TRUE` or `FALSE` (default), provide quartiles
-
     - name: pcEqGr
       title: Cut points for
       type: Bool
@@ -341,8 +333,8 @@ options:
     - name: pcValues
       title: Percentile values
       type: String
-      default: "0.05,0.95"
+      default: "0.25,0.5,0.75"
       description:
           R: >
-            a comma-sepated list (default: 0.05,0.95) specifying the percentiles
+            a comma-sepated list (default: 0.25,0.5,0.75) specifying the percentiles
 ...

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -329,4 +329,20 @@ options:
       description:
           R: >
             an integer (default: 4) specifying the number of equal groups
+
+    - name: pcVal
+      title: Percentile
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide percentiles
+
+    - name: pcValues
+      title: Percentile values
+      type: String
+      default: "0.05,0.95"
+      description:
+          R: >
+            a comma-sepated list (default: 0.05,0.95) specifying the percentiles
 ...

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -322,7 +322,7 @@ options:
           R: >
             an integer (default: 4) specifying the number of equal groups
 
-    - name: pcVal
+    - name: pc
       title: Percentile
       type: Bool
       default: false

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -340,7 +340,7 @@ options:
 
     - name: pcValues
       title: Percentile values
-      type: Text
+      type: String
       default: "0.05,0.95"
       description:
           R: >

--- a/jamovi/descriptives.r.yaml
+++ b/jamovi/descriptives.r.yaml
@@ -7,7 +7,7 @@ items:
     - name: descriptives
       title: Descriptives
       description: a table of the descriptive statistics
-      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr || pcVal)
+      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pcVal)
       type: Table
       rows: 1
       clearWith:

--- a/jamovi/descriptives.r.yaml
+++ b/jamovi/descriptives.r.yaml
@@ -7,7 +7,7 @@ items:
     - name: descriptives
       title: Descriptives
       description: a table of the descriptive statistics
-      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pcVal)
+      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pc)
       type: Table
       rows: 1
       clearWith:

--- a/jamovi/descriptives.r.yaml
+++ b/jamovi/descriptives.r.yaml
@@ -7,12 +7,13 @@ items:
     - name: descriptives
       title: Descriptives
       description: a table of the descriptive statistics
-      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr)
+      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || quart || pcEqGr || pcVal)
       type: Table
       rows: 1
       clearWith:
         - splitBy
         - pcNEqGr
+        - pcValues
       columns: []
 
     - name: frequencies

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -87,6 +87,7 @@ children:
                     children:
                       - type: TextBox
                         name: pcValues
+                        format: string
                         label: ''
                         suffix: (comma sep)
                         enable: (pcVal)

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -77,6 +77,19 @@ children:
                         suffix: equal groups
                         format: number
                         enable: (pcEqGr)
+              - type: LayoutBox
+                children:
+                  - type: CheckBox
+                    name: pcVal
+                    label: Percentiles
+                    style: inline
+                    verticalAlignment: center
+                    children:
+                      - type: TextBox
+                        name: pcValues
+                        label: ''
+                        suffix: (comma sep)
+                        enable: (pcVal)
       - type: LayoutBox
         stretchFactor: 1
         margin: large

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -87,6 +87,7 @@ children:
                         name: pcValues
                         label: ''
                         format: string
+                        width: large
                         enable: (pcVal)
       - type: LayoutBox
         stretchFactor: 1

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -77,6 +77,19 @@ children:
                         suffix: equal groups
                         format: number
                         enable: (pcEqGr)
+              - type: LayoutBox
+                children:
+                  - type: CheckBox
+                    name: pcVal
+                    label: Percentiles
+                    style: inline
+                    verticalAlignment: center
+                    children:
+                      - type: TextBox
+                        name: pcValues
+                        label: ''
+                        format: string
+                        enable: (pcVal)
       - type: LayoutBox
         stretchFactor: 1
         margin: large

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -61,8 +61,6 @@ children:
           - type: Label
             label: Percentile Values
             children:
-              - type: CheckBox
-                name: quart
               - type: LayoutBox
                 children:
                   - type: CheckBox

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -78,7 +78,7 @@ children:
               - type: LayoutBox
                 children:
                   - type: CheckBox
-                    name: pcVal
+                    name: pc
                     label: Percentiles
                     style: inline
                     verticalAlignment: center
@@ -88,7 +88,7 @@ children:
                         label: ''
                         format: string
                         width: large
-                        enable: (pcVal)
+                        enable: (pc)
       - type: LayoutBox
         stretchFactor: 1
         margin: large

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -87,8 +87,8 @@ children:
                     children:
                       - type: TextBox
                         name: pcValues
-                        format: string
                         label: ''
+                        format: string
                         enable: (pcVal)
       - type: LayoutBox
         stretchFactor: 1

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -89,7 +89,6 @@ children:
                         name: pcValues
                         format: string
                         label: ''
-                        suffix: (comma sep)
                         enable: (pcVal)
       - type: LayoutBox
         stretchFactor: 1

--- a/jamovi/ttestis.u.yaml
+++ b/jamovi/ttestis.u.yaml
@@ -175,4 +175,4 @@ children:
                 maxItemCount: 1
                 isTarget: true
                 permitted:
-                  - output
+                  - numeric

--- a/jamovi/ttestis.u.yaml
+++ b/jamovi/ttestis.u.yaml
@@ -175,4 +175,4 @@ children:
                 maxItemCount: 1
                 isTarget: true
                 permitted:
-                  - numeric
+                  - output

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -9,7 +9,7 @@ test_that('descriptives works', {
     z <- c(NA,NaN,3,-1,-2,1,1,-2,2,-2,-3,3)
 
     data <- data.frame(w=w, x=x, y=y, z=z)
-    desc <- jmv::descriptives(data, vars=c("w", "y", "z"), splitBy = "x", freq=TRUE, median=TRUE, mode=TRUE, skew=TRUE, kurt=TRUE, quart=TRUE)
+    desc <- jmv::descriptives(data, vars=c("w", "y", "z"), splitBy = "x", freq=TRUE, median=TRUE, mode=TRUE, skew=TRUE, kurt=TRUE, pc=TRUE)
 
     freq <- desc$frequencies[[1]]$asDF
     descr <- desc$descriptives$asDF
@@ -25,7 +25,7 @@ test_that('descriptives works', {
     expect_equal(5.750, descr$`y[meana]`, tolerance = 1e-3)
     expect_equal(-2, descr$`z[modeb]`, tolerance = 1e-3)
     expect_equal(4, descr$`y[mina]`, tolerance = 1e-3)
-    expect_equal(2.25, descr$`y[quart1c]`, tolerance = 1e-3)
+    expect_equal(2.25, descr$`y[perc1c]`, tolerance = 1e-3)
 
 })
 


### PR DESCRIPTION
Currently you can get quantile up to 10 groups in descriptives. I needed the 5th and 95th percentiles, so I propose a new option to generate a comma-delimited list of arbitrary percentiles.
The TextBox is small and I don't know if it could be made larger. 
I have set as default 0.05,0.95 to indicate that any percentile list can be used.