### PR TITLE
descriptives: IQR, CV & mean in boxplot

### DIFF
--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -5,15 +5,16 @@ descriptivesClass <- R6::R6Class(
     private=list(
         #### Member variables ----
         colArgs = list(
-            name = c("n", "missing", "mean", "se", "median", "mode", "sum", "sd", "variance", "range",
+            name = c("n", "missing", "mean", "se", "median", "mode", "sum", "sd", "variance", "iqr", "cv","range",
                      "min", "max", "skew", "seSkew", "kurt", "seKurt", "sww", "sw"),
             title = c("N", "Missing", "Mean", "Std. error mean", "Median", "Mode", "Sum", "Standard deviation", "Variance",
+                      "IQR", "Coeff. variation", 
                       "Range", "Minimum", "Maximum", "Skewness", "Std. error skewness",
                       "Kurtosis", "Std. error kurtosis", "Shapiro-Wilk W", "Shapiro-Wilk p"),
-            type = c(rep("integer", 2), rep("number", 16)),
-            format = c(rep("", 17), "zto,pvalue"),
-            visible = c("(n)", "(missing)", "(mean)", "(se)", "(median)", "(mode)", "(sum)", "(sd)", "(variance)", "(range)",
-                        "(min)", "(max)", "(skew)", "(skew)", "(kurt)", "(kurt)", "(sw)", "(sw)")
+            type = c(rep("integer", 2), rep("number", 18)),
+            format = c(rep("", 19), "zto,pvalue"),
+            visible = c("(n)", "(missing)", "(mean)", "(se)", "(median)", "(mode)", "(sum)", "(sd)", "(variance)", 
+                        "(iqr)","(cv)","(range)", "(min)", "(max)", "(skew)", "(skew)", "(kurt)", "(kurt)", "(sw)", "(sw)")
         ),
         levels = NULL,
 
@@ -1085,6 +1086,8 @@ descriptivesClass <- R6::R6Class(
                 stats[['min']] <- min(column)
                 stats[['max']] <- max(column)
                 stats[['se']] <- sqrt(var(column)/length(column))
+                stats[['iqr']] <- diff(as.numeric(quantile(column, c(.25,.75))))
+                stats[['cv']] <- sd(column)/mean(column)
 
                 deviation <- column-mean(column)
                 skew <- private$.skewness(column)

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -347,7 +347,7 @@ descriptivesClass <- R6::R6Class(
                             renderFun = ".boxPlot",
                             width = size[1],
                             height = size[2],
-                            clearWith = list("splitBy", "box", "violin", "dot", "dotType")
+                            clearWith = list("splitBy", "box", "violin", "dot", "dotType", "boxmean")
                         )
 
                         group$add(image)
@@ -955,6 +955,9 @@ descriptivesClass <- R6::R6Class(
                                                    outlier.shape=outlier.shape)
                 }
 
+                if (self$options$boxmean)
+                    plot <- plot + stat_summary(fun.y=mean, geom="point", shape=22, size=2, color="blue", fill="blue")
+
                 if (is.null(splitBy))
                     themeSpec <- theme(axis.text.x=element_blank(),
                                        axis.ticks.x=element_blank(),
@@ -984,6 +987,9 @@ descriptivesClass <- R6::R6Class(
                     plot <- plot + ggplot2::geom_boxplot(color=theme$color[1], width=0.3, alpha=0.8,
                                                          outlier.colour=theme$color[1],
                                                          position=position_dodge(0.9))
+                if (self$options$boxmean)
+                    plot <- plot + stat_summary(fun.y=mean, geom="point", shape=22, size=2, color="blue", fill="blue")
+
             }
 
             if (length(splitBy) > 2)

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -26,6 +26,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             sum = FALSE,
             sd = TRUE,
             variance = FALSE,
+            iqr = FALSE,
+            cv = FALSE,
             range = FALSE,
             min = TRUE,
             max = TRUE,
@@ -136,6 +138,14 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                 "variance",
                 variance,
                 default=FALSE)
+            private$..iqr <- jmvcore::OptionBool$new(
+                "iqr",
+                iqr,
+                default=TRUE)
+            private$..cv <- jmvcore::OptionBool$new(
+                "cv",
+                cv,
+                default=TRUE)
             private$..range <- jmvcore::OptionBool$new(
                 "range",
                 range,
@@ -203,6 +213,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..sum)
             self$.addOption(private$..sd)
             self$.addOption(private$..variance)
+            self$.addOption(private$..iqr)
+            self$.addOption(private$..cv)
             self$.addOption(private$..range)
             self$.addOption(private$..min)
             self$.addOption(private$..max)
@@ -236,6 +248,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         sum = function() private$..sum$value,
         sd = function() private$..sd$value,
         variance = function() private$..variance$value,
+        iqr = function() private$..iqr$value,
+        cv = function() private$..cv$value,
         range = function() private$..range$value,
         min = function() private$..min$value,
         max = function() private$..max$value,
@@ -268,6 +282,8 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..sum = NA,
         ..sd = NA,
         ..variance = NA,
+        ..iqr = NA,
+        ..cv = NA,
         ..range = NA,
         ..min = NA,
         ..max = NA,
@@ -298,7 +314,7 @@ descriptivesResults <- if (requireNamespace('jmvcore')) R6::R6Class(
                 options=options,
                 name="descriptives",
                 title="Descriptives",
-                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pc)",
+                visible="(n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || iqr || cv || skew || kurt || pcEqGr || pc)",
                 rows=1,
                 clearWith=list(
                     "splitBy",
@@ -442,6 +458,10 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #'   deviation
 #' @param variance \code{TRUE} or \code{FALSE} (default), provide the variance
 #' @param range \code{TRUE} or \code{FALSE} (default), provide the range
+#' @param iqr \code{TRUE} (default) or \code{FALSE}, provide the interquartile
+#'   range
+#' @param cv \code{TRUE} (default) or \code{FALSE}, provide the coefficient of
+#'   variation
 #' @param min \code{TRUE} or \code{FALSE} (default), provide the minimum
 #' @param max \code{TRUE} or \code{FALSE} (default), provide the maximum
 #' @param se \code{TRUE} or \code{FALSE} (default), provide the standard error
@@ -491,6 +511,8 @@ descriptives <- function(
     sum = FALSE,
     sd = TRUE,
     variance = FALSE,
+    iqr = FALSE,
+    cv = FALSE,
     range = FALSE,
     min = TRUE,
     max = TRUE,
@@ -553,6 +575,8 @@ descriptives <- function(
         sum = sum,
         sd = sd,
         variance = variance,
+        iqr = iqr,
+        cv = cv,
         range = range,
         min = min,
         max = max,

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -17,6 +17,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             violin = FALSE,
             dot = FALSE,
             dotType = "jitter",
+            boxmean = FALSE,
             qq = FALSE,
             n = TRUE,
             missing = TRUE,
@@ -102,6 +103,10 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
                     "jitter",
                     "stack"),
                 default="jitter")
+            private$..boxmean <- jmvcore::OptionBool$new(
+                "boxmean",
+                boxmean,
+                default=FALSE)
             private$..qq <- jmvcore::OptionBool$new(
                 "qq",
                 qq,
@@ -204,6 +209,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
             self$.addOption(private$..violin)
             self$.addOption(private$..dot)
             self$.addOption(private$..dotType)
+            self$.addOption(private$..boxmean)
             self$.addOption(private$..qq)
             self$.addOption(private$..n)
             self$.addOption(private$..missing)
@@ -239,6 +245,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         violin = function() private$..violin$value,
         dot = function() private$..dot$value,
         dotType = function() private$..dotType$value,
+        boxmean = function() private$..boxmean$value,
         qq = function() private$..qq$value,
         n = function() private$..n$value,
         missing = function() private$..missing$value,
@@ -273,6 +280,7 @@ descriptivesOptions <- if (requireNamespace('jmvcore')) R6::R6Class(
         ..violin = NA,
         ..dot = NA,
         ..dotType = NA,
+        ..boxmean = NA,
         ..qq = NA,
         ..n = NA,
         ..missing = NA,
@@ -445,6 +453,8 @@ descriptivesBase <- if (requireNamespace('jmvcore')) R6::R6Class(
 #' @param dot \code{TRUE} or \code{FALSE} (default), provide dot plots
 #'   (continuous variables only)
 #' @param dotType .
+#' @param boxmean \code{TRUE} or \code{FALSE} (default), add mean to
+#'   box plot
 #' @param qq \code{TRUE} or \code{FALSE} (default), provide Q-Q plots
 #'   (continuous variables only)
 #' @param n \code{TRUE} (default) or \code{FALSE}, provide the sample size
@@ -502,6 +512,7 @@ descriptives <- function(
     violin = FALSE,
     dot = FALSE,
     dotType = "jitter",
+    boxmean = FALSE,
     qq = FALSE,
     n = TRUE,
     missing = TRUE,
@@ -566,6 +577,7 @@ descriptives <- function(
         violin = violin,
         dot = dot,
         dotType = dotType,
+        boxmean = boxmean,
         qq = qq,
         n = n,
         missing = missing,

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -176,6 +176,14 @@ options:
           title: "Stacked"
       default: jitter
 
+    - name: boxmean
+      title: Add mean
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), add mean to box plot
+
     - name: qq
       title: Q-Q plot
       type: Bool

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -280,6 +280,22 @@ options:
           R: >
             `TRUE` or `FALSE` (default), provide the standard error
 
+    - name: iqr
+      title: IQR
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide the interquartile range
+
+    - name: cv
+      title: Coefficient of variation
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide the coefficient of variation
+
     - name: skew
       title: Skewness
       type: Bool

--- a/jamovi/descriptives.r.yaml
+++ b/jamovi/descriptives.r.yaml
@@ -7,7 +7,7 @@ items:
     - name: descriptives
       title: Descriptives
       description: a table of the descriptive statistics
-      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || skew || kurt || pcEqGr || pc)
+      visible: (n || missing || mean || median || mode || sum || sd || variance || range || min || max || se || iqr || cv || skew || kurt || pcEqGr || pc)
       type: Table
       rows: 1
       clearWith:

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -208,6 +208,8 @@ children:
                   - type: ComboBox
                     name: dotType
                     enable: (dot)
+              - type: CheckBox
+                name: boxmean
           - type: Label
             label: Bar Plots
             stretchFactor: 1

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -130,6 +130,8 @@ children:
                     name: variance
                   - type: CheckBox
                     name: range
+                  - type: CheckBox
+                    name: iqr
               - type: LayoutBox
                 margin: normal
                 children:
@@ -140,6 +142,9 @@ children:
                   - type: CheckBox
                     name: se
                     label: S. E. Mean
+                  - type: CheckBox
+                    name: cv
+                    label: Coeff. variation
       - type: LayoutBox
         stretchFactor: 1
         margin: large


### PR DESCRIPTION
Hi,
This addition follows some requests: descriptives can show the IQR and the coefficient of variation. 
For CV I have used sd/mean without multiplying by 100 as is done some times.

Also, a blue dot with the mean can be added to boxplot, violin or dot plots.
Color, shape and size are fixed to make it simple.

I hope you like it
Victor
