### PR TITLE
EFA/PCA: change r.scores > Phi table for factor correlations

### DIFF
--- a/R/efa.h.R
+++ b/R/efa.h.R
@@ -249,7 +249,7 @@ efaBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   loadings by size
 #' @param screePlot \code{TRUE} or \code{FALSE} (default), show scree plot
 #' @param eigen \code{TRUE} or \code{FALSE} (default), show eigenvalue table
-#' @param factorCor \code{TRUE} or \code{FALSE} (default), show factor
+#' @param factorCor \code{TRUE} or \code{FALSE} (default), show inter-factor
 #'   correlations
 #' @param factorSummary \code{TRUE} or \code{FALSE} (default), show factor
 #'   summary

--- a/R/pca.b.R
+++ b/R/pca.b.R
@@ -36,7 +36,7 @@ pcaClass <- R6::R6Class(
         },
         factorCor = function() {
             if (is.null(private$.factorCor))
-                private$.factorCor <- private$.getPsychResult()$r.scores
+                private$.factorCor <- private$.getPsychResult()$Phi
 
             return(private$.factorCor)
         },
@@ -110,6 +110,7 @@ pcaClass <- R6::R6Class(
             private$.initModelFitTable()
             private$.initEigenTable()
             private$.initKMOTable()
+            private$.initFactorCor()
         },
         .run = function() {
             if (is.null(self$options$vars) || length(self$options$vars) < 2)
@@ -219,6 +220,12 @@ pcaClass <- R6::R6Class(
 
             for (i in seq_along(vars))
                 table$addRow(rowKey=i+1, values=list(name = vars[[i]]))
+        },
+        .initFactorCor = function() {
+            if (private$analysis == 'efa') {
+                table <- self$results$factorStats$factorCor
+                table$setTitle("Inter-Factor Correlations")
+            }
         },
 
         #### Populate tables/plots functions ----
@@ -332,8 +339,6 @@ pcaClass <- R6::R6Class(
                     table$addColumn(name=paste0("pc",i), title=as.character(i), type='number')
             }
 
-            colNames <- sub('.', '', colnames(factorCor))
-
             for (i in 1:nFactors) {
                 row <- list()
                 row[["comp"]] <- i
@@ -344,7 +349,7 @@ pcaClass <- R6::R6Class(
                     else if (j < i)
                         row[[paste0("pc", j)]] <- ""
                     else
-                        row[[paste0("pc", j)]] <- factorCor[i, j]
+                        row[[paste0("pc", j)]] <- ifelse(is.null(factorCor), 0, factorCor[i, j])
                 }
 
                 table$addRow(rowKey=i, values=row)

--- a/R/pca.h.R
+++ b/R/pca.h.R
@@ -232,7 +232,7 @@ pcaResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                         self$add(jmvcore::Table$new(
                             options=options,
                             name="factorCor",
-                            title="Correlation Matrix",
+                            title="Inter-Component Correlations",
                             visible="(factorCor)",
                             clearWith=list(
                                 "vars",
@@ -483,7 +483,7 @@ pcaBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   loadings by size
 #' @param screePlot \code{TRUE} or \code{FALSE} (default), show scree plot
 #' @param eigen \code{TRUE} or \code{FALSE} (default), show eigenvalue table
-#' @param factorCor \code{TRUE} or \code{FALSE} (default), show factor
+#' @param factorCor \code{TRUE} or \code{FALSE} (default), show inter-factor
 #'   correlations
 #' @param factorSummary \code{TRUE} or \code{FALSE} (default), show factor
 #'   summary

--- a/jamovi/efa.a.yaml
+++ b/jamovi/efa.a.yaml
@@ -159,7 +159,7 @@ options:
       default: false
       description:
           R: >
-            `TRUE` or `FALSE` (default), show factor correlations
+            `TRUE` or `FALSE` (default), show inter-factor correlations
 
     - name: factorSummary
       title: Factor summary

--- a/jamovi/pca.a.yaml
+++ b/jamovi/pca.a.yaml
@@ -139,7 +139,7 @@ options:
       default: false
       description:
           R: >
-            `TRUE` or `FALSE` (default), show factor correlations
+            `TRUE` or `FALSE` (default), show inter-factor correlations
 
     - name: factorSummary
       title: Component summary

--- a/jamovi/pca.r.yaml
+++ b/jamovi/pca.r.yaml
@@ -58,7 +58,7 @@ items:
               type: number
 
         - name: factorCor
-          title: Correlation Matrix
+          title: Inter-Component Correlations
           visible: (factorCor)
           type: Table
           clearWith:


### PR DESCRIPTION
- EFA/PCA was presenting the factor score correlations in the factor correlations table. Changed this to use the phi correlation table.
- Also changed the name of table to be more clear.

Should fix jamovi/jamovi#706