### PR TITLE
linReg: fix bug that throws error when predictor has one level

### DIFF
--- a/R/linreg.b.R
+++ b/R/linreg.b.R
@@ -1249,8 +1249,15 @@ linRegClass <- R6::R6Class(
             refVars <- sapply(refLevels, function(x) x$var)
 
             for (factor in factors) {
+                if (length(levels(dataRaw[[factor]])) <= 1)
+                    stop(jmvcore::format("Factor '{}' needs to have at least 2 levels", factor))
+
                 ref <- refLevels[[which(factor == refVars)]][['ref']]
-                column <- dataRaw[[factor]]
+                column <- factor(
+                    dataRaw[[factor]],
+                    ordered = FALSE,
+                    levels = levels(dataRaw[[factor]])
+                )
                 levels(column) <- jmvcore::toB64(levels(column))
                 column <- relevel(column, ref = jmvcore::toB64(ref))
 
@@ -1330,7 +1337,7 @@ linRegClass <- R6::R6Class(
         },
         .scaleData = function(data) {
             for (col in names(data)) {
-                if ( ! is.factor(data[[col]]))
+                if ( ! is.factor(data[[col]]) && length(unique(data[[col]])) > 1 )
                     data[[col]] <- scale(data[[col]])
             }
 

--- a/tests/testthat/testlinreg.R
+++ b/tests/testthat/testlinreg.R
@@ -184,3 +184,49 @@ test_that("analysis shows warning note on singular fit", {
     expect_equal(noteCoef, "Linear model contains aliased coefficients (singular fit)")
     expect_equal(noteVIF, "Linear model contains aliased coefficients (singular fit)")
 })
+
+test_that("analysis works for covariate with one unique value", {
+
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+
+    df <- data.frame(
+        x = rep(1, 100),
+        y = rnorm(100)
+    )
+
+    r <- jmv::linReg(
+        df,
+        dep="y",
+        covs="x",
+        blocks=list(list("x")),
+    )
+
+    coef <- r$models[[1]]$coef$asDF
+    expect_equal(0.237, coef[1, "est"], tolerance = 1e-4)
+    expect_equal(NaN, coef[2, "est"])
+})
+
+test_that("analysis throws error for factor with one level", {
+
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+
+    df <- data.frame(
+        x = factor(rep(1, 100)),
+        y = rnorm(100)
+    )
+
+    testthat::expect_error(
+        {
+            jmv::linReg(
+                df,
+                dep="y",
+                factors="x",
+                blocks=list(list("x")),
+                refLevels = list(list(var="x", ref="1"))
+            )
+        },
+        regexp = "needs to have at least 2 levels"
+    )
+})


### PR DESCRIPTION
* For covariate, run the analysis and "aliased" footnote appears
* For factor, throw clearer error message