### PR TITLE
Update proptest2.h.R

### DIFF
--- a/R/proptest2.h.R
+++ b/R/proptest2.h.R
@@ -32,7 +32,7 @@ propTest2Options <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "nominal",
                     "ordinal"),
                 permitted=list(
-                    "factor"))
+                    "factor", "numeric", "continuous"))
             private$..areCounts <- jmvcore::OptionBool$new(
                 "areCounts",
                 areCounts,


### PR DESCRIPTION
 Currently, when we enter data in aggregate format (the option "Values are counts"), jamovi still expects an ordinal or nominal variable.  However, strictly speaking, the counts are numeric and if we change the "Measure type" to continuous, the variable with the counts is no longer accepted in the variable box for the Binomial Test.

Notice that in contrast to the above, in the McNemar's test command, the type of variable expected in the "counts" field, is correctly specified as "continuous"!

I suggest adding to lines 34/35 other types of variables

permitted=list(
                    "factor", "numeric", "continuous"))