### PR TITLE
ANOVA: catch uninformative error message Q-Q plot

### DIFF
--- a/R/ancova.b.R
+++ b/R/ancova.b.R
@@ -80,7 +80,7 @@ ancovaClass <- R6::R6Class(
             modelTerms <- private$.modelTerms()
 
             singularErrorMessage <- .("Singular fit encountered; one or more predictor variables are a linear combination of other predictor variables.")
-            perfectFitErrorMessage <- .("Residual sum of squares and/or degrees of freedom is zero, indicating a perfect fit")
+            perfectFitErrorMessage <- .("Residual sum of squares and/or degrees of freedom are zero, indicating a perfect fit")
 
             suppressWarnings({
 
@@ -649,7 +649,7 @@ ancovaClass <- R6::R6Class(
         #### Plot functions ----
         .qqPlot=function(image, ggtheme, theme, ...) {
             residuals <- rstandard(self$model)
-            if (is.null(residuals))
+            if (is.null(residuals) || all(is.na(residuals)))
                 return()
 
             df <- as.data.frame(qqnorm(residuals, plot.it=FALSE))

--- a/tests/testthat/testanova.R
+++ b/tests/testthat/testanova.R
@@ -3,6 +3,18 @@ context('anova')
 
 data('ToothGrowth')
 
+test_that('Correct error message is with perfect fit of the model', {
+    df <- data.frame(
+        dep = c(90, 87, 75, 60, 35, 50, 65, 70),
+        var = factor(1:8)
+    )
+
+    testthat::expect_error(
+        jmv::ANOVA(df, dep='dep', factors='var', qq=TRUE),
+        "perfect fit"
+    )
+})
+
 test_that('anova works', {
 
     r <- jmv::ANOVA(ToothGrowth, dep='len', factors=c('dose', 'supp'))


### PR DESCRIPTION
Previously, the ANOVA would throw an unclear error message ("y is empty or has only NAs") when the model had a perfect fit and the Q-Q plot assumption test was checked. This commit catches the "perfect fit" before the Q-Q plot is constructed.

Addresses https://github.com/jamovi/jamovi-fun-todo-list/issues/44#issuecomment-1126601759