### PR TITLE
Descriptives: prevent error for factor with all missing values

### DIFF
--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -304,7 +304,7 @@ descriptivesClass <- R6::R6Class(
                 table$addColumn(name='pc', title=.('% of Total'), type='number', format='pc')
                 table$addColumn(name='cumpc', title=.('Cumulative %'), type='number', format='pc')
 
-                for (row in 1:nrow(grid)) {
+                for (row in seq_len(nrow(grid))) {
                     rowValues <- list()
                     for (col in tableVars)
                         rowValues[[col]] <- as.character(grid[row, col])
@@ -639,7 +639,7 @@ descriptivesClass <- R6::R6Class(
                 n <- sum(freq)
                 cumsum <- 0
 
-                for (row in 1:nrow(grid)) {
+                for (row in seq_len(nrow(grid))) {
                     counts <- do.call("[", c(list(freq), grid[row, ]))
                     cumsum <- cumsum + counts
                     pc <- counts / n

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -790,7 +790,7 @@ descriptivesClass <- R6::R6Class(
                             }
 
                         } else {
-                            plotData <- data.frame(x=character())
+                            plotData <- data.frame(x=numeric())
                             names <- list("x"="x", "s1"=NULL, "s2"=NULL, "s3"=NULL)
                             labels <- list("x"=var, "s1"=NULL, "s2"=NULL, "s3"=NULL)
                         }

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -46,6 +46,9 @@ descriptivesClass <- R6::R6Class(
             )
 
             private$.addQuantiles()
+
+            private$.errorCheck()
+
             private$.initDescriptivesTable()
             private$.initDescriptivesTTable()
             private$.initFrequencyTables()
@@ -128,7 +131,7 @@ descriptivesClass <- R6::R6Class(
                 }
 
                 if (length(splitBy) > 0) {
-                    for (j in 1:nrow(grid)) {
+                    for (j in seq_len(nrow(grid))) {
                         post <- paste0(
                             "[", name, paste0(grid[j,], collapse = ""), "]"
                         )
@@ -261,7 +264,7 @@ descriptivesClass <- R6::R6Class(
             iter <- 1
             for (i in seq_along(vars)) {
                 if (length(splitBy) > 0) {
-                    for (j in 1:nrow(grid)) {
+                    for (j in seq_len(nrow(grid))) {
                         values <- list("vars"=vars[i])
                         for (k in seq_along(splitBy))
                             values[[splitBy[k]]] <- grid[j, k]
@@ -466,7 +469,7 @@ descriptivesClass <- R6::R6Class(
             iter <- 1
             for (i in seq_along(vars)) {
                 if (length(splitBy) > 0) {
-                    for (j in 1:nrow(grid)) {
+                    for (j in seq_len(nrow(grid))) {
                         for (k in seq_along(colNames)) {
                             name <- colNames[k]
                             post <- paste0("[", name, paste0(grid[j,], collapse = ""), "]")
@@ -510,7 +513,7 @@ descriptivesClass <- R6::R6Class(
 
                 r <- desc[[vars[i]]]
                 if (length(splitBy) > 0) {
-                    for (j in 1:nrow(grid)) {
+                    for (j in seq_len(nrow(grid))) {
                         indices <- grid[j,]
                         stats <- do.call("[", c(list(r), indices))[[1]]
 
@@ -573,7 +576,7 @@ descriptivesClass <- R6::R6Class(
             for (i in seq_along(vars)) {
                 r <- desc[[vars[i]]]
                 if (length(splitBy) > 0) {
-                    for (j in 1:nrow(grid)) {
+                    for (j in seq_len(nrow(grid))) {
                         stats <- do.call("[", c(list(r), grid[j,]))[[1]]
                         values <- list()
                         for (k in seq_along(colNames)) {
@@ -1230,20 +1233,16 @@ descriptivesClass <- R6::R6Class(
                 for (item in splitBy) {
                     if ( ! is.factor(data[[item]])) {
                         jmvcore::reject(
-                            .('Unable to split by a continuous variable')
+                            .('Unable to split by a continuous variable'),
+                            code=exceptions$valueError
+                        )
+                    } else if (length(levels(data[[item]])) == 0) {
+                        jmvcore::reject(
+                            .("The 'split by' variable '{var}' contains no data."),
+                            code=exceptions$valueError,
+                            var=item
                         )
                     }
-                }
-            }
-
-            for (var in splitBy) {
-                if (length(levels(data[[var]])) == 0) {
-                    jmvcore::reject(
-                        jmvcore::format(
-                            .("The 'split by' variable '{var}' contains no data."), var=var
-                        ),
-                        code=''
-                    )
                 }
             }
         },

--- a/R/errors.R
+++ b/R/errors.R
@@ -68,3 +68,13 @@ checkData = function(self, data, types, B64 = FALSE) {
             variableContainsOneUniqueValue(self, col, colName)
     }
 }
+
+exceptions = list(
+    "attributeError" = "attributeError",
+    "indexError" = "indexError",
+    "keyError" = "keyError",
+    "modelError" = "modelError",
+    "nameError" = "nameError",
+    "valueError" = "valueError"
+)
+

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -193,3 +193,12 @@ test_that('histogram is created for nominal numeric variable', {
 
     expect_true(desc$plots[[2]]$.render())
 })
+
+testthat::test_that("No error is thrown when an empty factor is used as variable", {
+    data <- data.frame(x = factor(rep(NA, 10)))
+    result <- jmv::descriptives(data, "x", freq = TRUE)
+    desc <- result$descriptives$asDF
+
+    testthat::expect_equal(desc[["x[n]"]], 0)
+    testthat::expect_equal(desc[["x[missing]"]], 10)
+})

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -202,3 +202,15 @@ testthat::test_that("No error is thrown when an empty factor is used as variable
     testthat::expect_equal(desc[["x[n]"]], 0)
     testthat::expect_equal(desc[["x[missing]"]], 10)
 })
+
+testthat::test_that('Sensible error message is provided when splitBy var contains no data', {
+    df <- data.frame(
+        var = 1:10,
+        group = factor(rep(NA, 10))
+    )
+
+    testthat::expect_error(
+        jmv::descriptives(formula=var~group, data=df),
+        "The 'split by' variable 'group' contains no data."
+    )
+})


### PR DESCRIPTION
Previously, the frequency tables caused a vague error message when a factor with all missing values was added as a variable (`Table$addRow(): value is not atomic`). This PR prevents this error message from being thrown, while still providing the results that it can provide.

The second commit addresses the following: Previously, an uninformative error message was given if an empty splitBy variable was provided ("Table$addColumn(): title must be a string"). This commit makes sure a more informative error message is given.

The third commit addresses the following: Previously, an uninformative error was thrown if the user asks to label outliers in the box plot while one of the variables had no data. With this commit, an empty plot is shown instead (this is the customary behavior for all plots). 

Addresses https://github.com/jamovi/jamovi-fun-todo-list/issues/44#issuecomment-1149324232 and https://github.com/jamovi/jamovi-fun-todo-list/issues/44#issuecomment-876048112 and https://github.com/jamovi/jamovi-fun-todo-list/issues/44#issuecomment-1159318408