### PR TITLE
Descriptives: add extreme values table

### DIFF
--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -702,8 +702,6 @@ descriptivesClass <- R6::R6Class(
             tables <- self$results$extremeValues
             vars <- self$options$vars
 
-            note <- .('Number of requested extreme values is higher than the number of rows in the data.')
-
             for (i in seq_along(vars)) {
                 r <- results$extreme[[ vars[i] ]]
 
@@ -732,6 +730,7 @@ descriptivesClass <- R6::R6Class(
                     )
                 }
 
+                note <- .('Number of requested extreme values is higher than the number of rows in the data.')
                 if (extremeN > nrow(r$highest))
                     table$setNote("insufficientData", note)
             }

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -52,6 +52,7 @@ descriptivesClass <- R6::R6Class(
             private$.initDescriptivesTable()
             private$.initDescriptivesTTable()
             private$.initFrequencyTables()
+            private$.initExtremeTables()
             private$.initPlots()
 
             private$.errorCheck()
@@ -67,6 +68,7 @@ descriptivesClass <- R6::R6Class(
                 private$.populateDescriptivesTable(results)
                 private$.populateDescriptivesTTable(results)
                 private$.populateFrequencyTables(results)
+                private$.populateExtremeTables(results)
                 private$.preparePlots()
             }
         },
@@ -79,10 +81,15 @@ descriptivesClass <- R6::R6Class(
 
             desc <- list()
             freq <- list()
+            extreme <- list()
             for (var in vars) {
                 column <- data[[var]]
                 if (is.factor(column))
                     freq[[var]] <- table(jmvcore::select(self$data, c(var, splitBy)))
+
+                extreme[[var]] <- private$.computeExtreme(
+                    data.frame(rows=rownames(self$data), values=column)
+                )
 
                 column <- jmvcore::toNumeric(column)
                 if (length(splitBy) > 0) {
@@ -95,7 +102,7 @@ descriptivesClass <- R6::R6Class(
                 }
             }
 
-            return(list(desc=desc, freq=freq))
+            return(list(desc=desc, freq=freq, extreme=extreme))
         },
 
         #### Init tables/plots functions ----
@@ -314,6 +321,37 @@ descriptivesClass <- R6::R6Class(
                     for (col in tableVars)
                         rowValues[[col]] <- as.character(grid[row, col])
                     table$addRow(rowKey=row, values=rowValues)
+                }
+            }
+        },
+        .initExtremeTables = function() {
+            if ( ! self$options$extreme)
+                return()
+
+            extremeN <- self$options$extremeN
+            tables <- self$results$extremeValues
+            vars <- self$options$vars
+
+            for (i in seq_along(vars)) {
+                var <- vars[i]
+                table <- tables[[i]]
+
+                if (! jmvcore::canBeNumeric(self$data[[var]])) {
+                    table$setVisible(FALSE)
+                    next()
+                }
+
+                table$addFormat(rowNo=extremeN+1, col=1, Cell.BEGIN_GROUP)
+
+                iter <- 1
+                for (n in seq_len(extremeN)) {
+                    table$setRow(rowNo=iter, values=list(type="Highest", place=n))
+                    iter <- iter + 1
+                }
+
+                for (n in seq_len(extremeN)) {
+                    table$setRow(rowNo=iter, values=list(type="Lowest", place=n))
+                    iter <- iter + 1
                 }
             }
         },
@@ -654,6 +692,48 @@ descriptivesClass <- R6::R6Class(
 
                     table$setRow(rowNo=row, value=list(counts=counts, pc=pc, cumpc=cumpc))
                 }
+            }
+        },
+        .populateExtremeTables = function(results) {
+            if ( ! self$options$extreme)
+                return()
+
+            extremeN <- self$options$extremeN
+            tables <- self$results$extremeValues
+            vars <- self$options$vars
+
+            note <- .('Number of requested extreme values is higher than the number of rows in the data.')
+
+            for (i in seq_along(vars)) {
+                r <- results$extreme[[ vars[i] ]]
+
+                if (is.null(r))
+                    next()
+
+                table <- tables[[i]]
+
+                for (n in 1:nrow(r$highest)) {
+                    table$setRow(
+                        rowNo=n,
+                        values=list(
+                            row=r$highest[n,"rows"],
+                            value=r$highest[n,"values"]
+                        )
+                    )
+                }
+
+                for (n in 1:nrow(r$lowest)) {
+                    table$setRow(
+                        rowNo=extremeN + n,
+                        values=list(
+                            row=r$lowest[n,"rows"],
+                            value=r$lowest[n,"values"]
+                        )
+                    )
+                }
+
+                if (extremeN > nrow(r$highest))
+                    table$setNote("insufficientData", note)
             }
         },
 
@@ -1448,6 +1528,19 @@ descriptivesClass <- R6::R6Class(
                 stats <- append(stats, l)
             }
             return(stats)
+        },
+        .computeExtreme = function(df) {
+            extremeN = self$options$extremeN
+
+            if (! jmvcore::canBeNumeric(df$values))
+                return(NULL)
+
+            df$values = jmvcore::toNumeric(df$values)
+
+            lowest = head(df[order(df$values),], extremeN)
+            highest <- head(df[order(-df$values),], extremeN)
+
+            return(list(highest=highest, lowest=lowest))
         },
         .plotSize = function(levels, plot) {
             nLevels <- as.numeric(sapply(levels, length))

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -42,7 +42,9 @@ descriptivesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
             pcEqGr = FALSE,
             pcNEqGr = 4,
             pc = FALSE,
-            pcValues = "25,50,75", ...) {
+            pcValues = "25,50,75",
+            extreme = FALSE,
+            extremeN = 5, ...) {
 
             super$initialize(
                 package="jmv",
@@ -217,6 +219,16 @@ descriptivesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
                 "pcValues",
                 pcValues,
                 default="25,50,75")
+            private$..extreme <- jmvcore::OptionBool$new(
+                "extreme",
+                extreme,
+                default=FALSE)
+            private$..extremeN <- jmvcore::OptionInteger$new(
+                "extremeN",
+                extremeN,
+                default=5,
+                min=1,
+                max=20)
 
             self$.addOption(private$..vars)
             self$.addOption(private$..splitBy)
@@ -255,6 +267,8 @@ descriptivesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
             self$.addOption(private$..pcNEqGr)
             self$.addOption(private$..pc)
             self$.addOption(private$..pcValues)
+            self$.addOption(private$..extreme)
+            self$.addOption(private$..extremeN)
         }),
     active = list(
         vars = function() private$..vars$value,
@@ -293,7 +307,9 @@ descriptivesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
         pcEqGr = function() private$..pcEqGr$value,
         pcNEqGr = function() private$..pcNEqGr$value,
         pc = function() private$..pc$value,
-        pcValues = function() private$..pcValues$value),
+        pcValues = function() private$..pcValues$value,
+        extreme = function() private$..extreme$value,
+        extremeN = function() private$..extremeN$value),
     private = list(
         ..vars = NA,
         ..splitBy = NA,
@@ -331,7 +347,9 @@ descriptivesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
         ..pcEqGr = NA,
         ..pcNEqGr = NA,
         ..pc = NA,
-        ..pcValues = NA)
+        ..pcValues = NA,
+        ..extreme = NA,
+        ..extremeN = NA)
 )
 
 descriptivesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
@@ -341,6 +359,7 @@ descriptivesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
         descriptives = function() private$.items[["descriptives"]],
         descriptivesT = function() private$.items[["descriptivesT"]],
         frequencies = function() private$.items[["frequencies"]],
+        extremeValues = function() private$.items[["extremeValues"]],
         plots = function() private$.items[["plots"]]),
     private = list(),
     public=list(
@@ -386,6 +405,34 @@ descriptivesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Clas
                     clearWith=list(
                         "splitBy"),
                     columns=list())))
+            self$add(jmvcore::Array$new(
+                options=options,
+                name="extremeValues",
+                title="Extreme Values",
+                visible="(extreme)",
+                items="(vars)",
+                template=jmvcore::Table$new(
+                    options=options,
+                    title="Extreme values of $key",
+                    rows="(extremeN * 2)",
+                    columns=list(
+                        list(
+                            `name`="type", 
+                            `title`="", 
+                            `type`="text", 
+                            `combineBelow`=TRUE),
+                        list(
+                            `name`="place", 
+                            `title`="", 
+                            `type`="integer"),
+                        list(
+                            `name`="row", 
+                            `title`="Row number", 
+                            `type`="integer"),
+                        list(
+                            `name`="value", 
+                            `title`="Value", 
+                            `type`="number")))))
             self$add(jmvcore::Array$new(
                 options=options,
                 name="plots",
@@ -539,12 +586,17 @@ descriptivesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #' @param pc \code{TRUE} or \code{FALSE} (default), provide percentiles
 #' @param pcValues a comma-sepated list (default: 25,50,75) specifying the
 #'   percentiles
+#' @param extreme \code{TRUE} or \code{FALSE} (default), provide top-N extreme
+#'   (highest and lowest) values
+#' @param extremeN an integer (default: 5) specifying the number of extreme
+#'   values
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
 #' \tabular{llllll}{
 #'   \code{results$descriptives} \tab \tab \tab \tab \tab a table of the descriptive statistics \cr
 #'   \code{results$descriptivesT} \tab \tab \tab \tab \tab a table of the descriptive statistics \cr
 #'   \code{results$frequencies} \tab \tab \tab \tab \tab an array of frequency tables \cr
+#'   \code{results$extremeValues} \tab \tab \tab \tab \tab an array of extreme values tables \cr
 #'   \code{results$plots} \tab \tab \tab \tab \tab an array of descriptive plots \cr
 #' }
 #'
@@ -594,6 +646,8 @@ descriptives <- function(
     pcNEqGr = 4,
     pc = FALSE,
     pcValues = "25,50,75",
+    extreme = FALSE,
+    extremeN = 5,
     formula) {
 
     if ( ! requireNamespace("jmvcore", quietly=TRUE))
@@ -661,7 +715,9 @@ descriptives <- function(
         pcEqGr = pcEqGr,
         pcNEqGr = pcNEqGr,
         pc = pc,
-        pcValues = pcValues)
+        pcValues = pcValues,
+        extreme = extreme,
+        extremeN = extremeN)
 
     analysis <- descriptivesClass$new(
         options = options,

--- a/R/descriptives.h.R
+++ b/R/descriptives.h.R
@@ -586,8 +586,8 @@ descriptivesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #' @param pc \code{TRUE} or \code{FALSE} (default), provide percentiles
 #' @param pcValues a comma-sepated list (default: 25,50,75) specifying the
 #'   percentiles
-#' @param extreme \code{TRUE} or \code{FALSE} (default), provide top-N extreme
-#'   (highest and lowest) values
+#' @param extreme \code{TRUE} or \code{FALSE} (default), provide N most
+#'   extreme (highest and lowest) values
 #' @param extremeN an integer (default: 5) specifying the number of extreme
 #'   values
 #' @param formula (optional) the formula to use, see the examples

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -396,4 +396,22 @@ options:
       description:
           R: >
             a comma-sepated list (default: 25,50,75) specifying the percentiles
+
+    - name: extreme
+      title: Extreme values
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide top-N extreme (highest and lowest) values
+
+    - name: extremeN
+      title: Number of extreme values
+      type: Integer
+      default: 5
+      min: 1
+      max: 20
+      description:
+          R: >
+            an integer (default: 5) specifying the number of extreme values
 ...

--- a/jamovi/descriptives.a.yaml
+++ b/jamovi/descriptives.a.yaml
@@ -403,7 +403,7 @@ options:
       default: false
       description:
           R: >
-            `TRUE` or `FALSE` (default), provide top-N extreme (highest and lowest) values
+            `TRUE` or `FALSE` (default), provide N most extreme (highest and lowest) values
 
     - name: extremeN
       title: Number of extreme values

--- a/jamovi/descriptives.r.yaml
+++ b/jamovi/descriptives.r.yaml
@@ -45,6 +45,31 @@ items:
             - splitBy
           columns: []
 
+    - name: extremeValues
+      title: Extreme Values
+      type: Array
+      description: an array of extreme values tables
+      visible: (extreme)
+      items: (vars)
+      template:
+          title: Extreme values of $key
+          type: Table
+          rows: (extremeN * 2)
+          columns:
+            - name: type
+              title: ''
+              type: text
+              combineBelow: true
+            - name: place
+              title: ''
+              type: integer
+            - name: row
+              title: 'Row number'
+              type: integer
+            - name: value
+              title: 'Value'
+              type: number
+
     - name: plots
       title: Plots
       type: Array

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -57,7 +57,7 @@ children:
     collapsed: true
     children:
       - type: LayoutBox
-        stretchFactor: 2
+        stretchFactor: 3
         margin: large
         cell:
           column: 0
@@ -107,7 +107,7 @@ children:
                         width: large
                         enable: (pc)
       - type: LayoutBox
-        stretchFactor: 1
+        stretchFactor: 2
         margin: large
         cell:
           column: 1
@@ -126,7 +126,7 @@ children:
               - type: CheckBox
                 name: sum
       - type: LayoutBox
-        stretchFactor: 2
+        stretchFactor: 3
         margin: large
         cell:
           column: 0
@@ -178,7 +178,7 @@ children:
                         format: number
                         enable: (ci)
       - type: LayoutBox
-        stretchFactor: 1
+        stretchFactor: 2
         margin: large
         cell:
           column: 1
@@ -197,6 +197,23 @@ children:
             children:
               - type: CheckBox
                 name: sw
+          - type: Label
+            label: Outliers
+            children:
+              - type: LayoutBox
+                children:
+                  - type: CheckBox
+                    name: extreme
+                    label: Extremest
+                    style: inline
+                    verticalAlignment: center
+                    children:
+                      - type: TextBox
+                        name: extremeN
+                        label: ''
+                        suffix: values
+                        format: number
+                        enable: (extreme)
   - type: CollapseBox
     label: Plots
     collapsed: true

--- a/jamovi/descriptives.u.yaml
+++ b/jamovi/descriptives.u.yaml
@@ -57,7 +57,7 @@ children:
     collapsed: true
     children:
       - type: LayoutBox
-        stretchFactor: 3
+        stretchFactor: 5
         margin: large
         cell:
           column: 0
@@ -107,7 +107,7 @@ children:
                         width: large
                         enable: (pc)
       - type: LayoutBox
-        stretchFactor: 2
+        stretchFactor: 4
         margin: large
         cell:
           column: 1
@@ -126,7 +126,7 @@ children:
               - type: CheckBox
                 name: sum
       - type: LayoutBox
-        stretchFactor: 3
+        stretchFactor: 5
         margin: large
         cell:
           column: 0
@@ -178,7 +178,7 @@ children:
                         format: number
                         enable: (ci)
       - type: LayoutBox
-        stretchFactor: 2
+        stretchFactor: 4
         margin: large
         cell:
           column: 1
@@ -204,7 +204,7 @@ children:
                 children:
                   - type: CheckBox
                     name: extreme
-                    label: Extremest
+                    label: Most extreme
                     style: inline
                     verticalAlignment: center
                     children:

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -1,6 +1,6 @@
-context('descriptives')
+testthat::context('descriptives')
 
-test_that('descriptive statistics work for continuous variables without split by sunny', {
+testthat::test_that('descriptive statistics work for continuous variables without split by sunny', {
     CI_WIDTH <- 0.95
     QUANTS <- c(0.25, 0.50, 0.75)
 
@@ -28,35 +28,35 @@ test_that('descriptive statistics work for continuous variables without split by
     quantiles <- quantile(x, QUANTS)
 
     # Test descriptives table
-    expect_equal(n, r[["x[n]"]], tolerance = 1e-5)
-    expect_equal(missing, r[["x[missing]"]], tolerance = 1e-5)
-    expect_equal(mean, r[["x[mean]"]], tolerance = 1e-5)
-    expect_equal(se, r[["x[se]"]], tolerance = 1e-5)
-    expect_equal(ciLower, r[["x[ciLower]"]], tolerance = 1e-5)
-    expect_equal(ciUpper, r[["x[ciUpper]"]], tolerance = 1e-5)
-    expect_equal(median(x), r[["x[median]"]], tolerance = 1e-5)
-    expect_equal(mode, r[["x[mode]"]], tolerance = 1e-5)
-    expect_equal(sum(x), r[["x[sum]"]], tolerance = 1e-5)
-    expect_equal(sd(x), r[["x[sd]"]], tolerance = 1e-5)
-    expect_equal(var(x), r[["x[variance]"]], tolerance = 1e-5)
-    expect_equal(range(x)[2] - range(x)[1], r[["x[range]"]], tolerance = 1e-5)
-    expect_equal(min(x), r[["x[min]"]], tolerance = 1e-5)
-    expect_equal(max(x), r[["x[max]"]], tolerance = 1e-5)
-    expect_equal(0.11014, r[["x[skew]"]], tolerance = 1e-5)
-    expect_equal(0.24138, r[["x[seSkew]"]], tolerance = 1e-5)
-    expect_equal(-0.11958, r[["x[kurt]"]], tolerance = 1e-5)
-    expect_equal(0.47833, r[["x[seKurt]"]], tolerance = 1e-5)
-    expect_equal(as.numeric(shapiro$statistic), r[["x[sww]"]], tolerance = 1e-5)
-    expect_equal(as.numeric(shapiro$p.value), r[["x[sw]"]], tolerance = 1e-5)
-    expect_equal(as.numeric(quantiles[1]), r[["x[quant1]"]], tolerance = 1e-5)
-    expect_equal(as.numeric(quantiles[2]), r[["x[quant2]"]], tolerance = 1e-5)
-    expect_equal(as.numeric(quantiles[3]), r[["x[quant3]"]], tolerance = 1e-5)
+    testthat::expect_equal(n, r[["x[n]"]], tolerance = 1e-5)
+    testthat::expect_equal(missing, r[["x[missing]"]], tolerance = 1e-5)
+    testthat::expect_equal(mean, r[["x[mean]"]], tolerance = 1e-5)
+    testthat::expect_equal(se, r[["x[se]"]], tolerance = 1e-5)
+    testthat::expect_equal(ciLower, r[["x[ciLower]"]], tolerance = 1e-5)
+    testthat::expect_equal(ciUpper, r[["x[ciUpper]"]], tolerance = 1e-5)
+    testthat::expect_equal(median(x), r[["x[median]"]], tolerance = 1e-5)
+    testthat::expect_equal(mode, r[["x[mode]"]], tolerance = 1e-5)
+    testthat::expect_equal(sum(x), r[["x[sum]"]], tolerance = 1e-5)
+    testthat::expect_equal(sd(x), r[["x[sd]"]], tolerance = 1e-5)
+    testthat::expect_equal(var(x), r[["x[variance]"]], tolerance = 1e-5)
+    testthat::expect_equal(range(x)[2] - range(x)[1], r[["x[range]"]], tolerance = 1e-5)
+    testthat::expect_equal(min(x), r[["x[min]"]], tolerance = 1e-5)
+    testthat::expect_equal(max(x), r[["x[max]"]], tolerance = 1e-5)
+    testthat::expect_equal(0.11014, r[["x[skew]"]], tolerance = 1e-5)
+    testthat::expect_equal(0.24138, r[["x[seSkew]"]], tolerance = 1e-5)
+    testthat::expect_equal(-0.11958, r[["x[kurt]"]], tolerance = 1e-5)
+    testthat::expect_equal(0.47833, r[["x[seKurt]"]], tolerance = 1e-5)
+    testthat::expect_equal(as.numeric(shapiro$statistic), r[["x[sww]"]], tolerance = 1e-5)
+    testthat::expect_equal(as.numeric(shapiro$p.value), r[["x[sw]"]], tolerance = 1e-5)
+    testthat::expect_equal(as.numeric(quantiles[1]), r[["x[quant1]"]], tolerance = 1e-5)
+    testthat::expect_equal(as.numeric(quantiles[2]), r[["x[quant2]"]], tolerance = 1e-5)
+    testthat::expect_equal(as.numeric(quantiles[3]), r[["x[quant3]"]], tolerance = 1e-5)
 
     # Check footnote for including CI
-    expect_match(desc$descriptives$notes$ci$note, "t-distribution")
+    testthat::expect_match(desc$descriptives$notes$ci$note, "t-distribution")
 })
 
-test_that('descriptives transposed table works with splitBy', {
+testthat::test_that('descriptives transposed table works with splitBy', {
     suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)
     df <- data.frame(
@@ -73,30 +73,30 @@ test_that('descriptives transposed table works with splitBy', {
 
     r <- desc$descriptivesT$asDF
 
-    expect_equal(c(36, 28, 36, 36, 28, 36, 36, 28, 36, 36, 28, 36), r$n)
-    expect_equal(
+    testthat::expect_equal(c(36, 28, 36, 36, 28, 36, 36, 28, 36, 36, 28, 36), r$n)
+    testthat::expect_equal(
         c(0.1454, 0.2344, 0.3307, 0.09781, -0.02078, 0.03245, -0.2239, -0.1114,
           -0.1302, -0.005095, -0.1445, 0.01393),
         r$mean, tolerance=1e-4
     )
-    expect_equal(
+    testthat::expect_equal(
         c(1.138, 0.8853, 1.138, 0.9002, 1.178, 0.9884, 1.044, 1.225, 0.9436,
           0.8925, 1.070, 0.843),
         r$sd, tolerance=1e-3
     )
-    expect_equal(
+    testthat::expect_equal(
         c(-2.344, -1.774, -1.679, -1.154, -2.474, -2.32, -2.38, -2.689, -1.979,
           -1.697, -1.867, -1.493),
         r$min, tolerance=1e-3
     )
-    expect_equal(
+    testthat::expect_equal(
         c(2.199, 1.785, 3.446, 3.104, 2.929, 2.209, 2.258, 3.406, 1.933, 1.851,
           1.898, 2.163),
         r$max, tolerance=1e-4
     )
 })
 
-test_that("Frequency table is displayed correctly for empty data set", {
+testthat::test_that("Frequency table is displayed correctly for empty data set", {
     df <- data.frame(
         dep = factor(levels = letters[1:3]),
         group = factor(levels = LETTERS[1:3])
@@ -105,14 +105,14 @@ test_that("Frequency table is displayed correctly for empty data set", {
     desc <- jmv::descriptives(data = df, vars = "dep", splitBy = "group", freq = TRUE)
     freq <- desc$frequencies[[1]]$asDF
 
-    expect_equal(rep(letters[1:3], each=3), freq[[1]])
-    expect_equal(rep(LETTERS[1:3], times=3), freq[[2]])
-    expect_equal(rep(0, 9), freq$counts)
-    expect_equal(rep(0, 9), freq$pc)
-    expect_equal(rep(0, 9), freq$cumpc)
+    testthat::expect_equal(rep(letters[1:3], each=3), freq[[1]])
+    testthat::expect_equal(rep(LETTERS[1:3], times=3), freq[[2]])
+    testthat::expect_equal(rep(0, 9), freq$counts)
+    testthat::expect_equal(rep(0, 9), freq$pc)
+    testthat::expect_equal(rep(0, 9), freq$cumpc)
 })
 
-test_that("Non-grouped frequency table is displayed correctly", {
+testthat::test_that("Non-grouped frequency table is displayed correctly", {
     suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)
 
@@ -125,13 +125,13 @@ test_that("Non-grouped frequency table is displayed correctly", {
 
     counts <- as.vector(table(df))
 
-    expect_equal(letters[1:3], freq$dep)
-    expect_equal(counts, freq$counts)
-    expect_equal(counts / sum(counts), freq$pc)
-    expect_equal(cumsum(counts) / sum(counts), freq$cumpc)
+    testthat::expect_equal(letters[1:3], freq$dep)
+    testthat::expect_equal(counts, freq$counts)
+    testthat::expect_equal(counts / sum(counts), freq$pc)
+    testthat::expect_equal(cumsum(counts) / sum(counts), freq$cumpc)
 })
 
-test_that("Grouped frequency table is displayed correctly", {
+testthat::test_that("Grouped frequency table is displayed correctly", {
     suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)
 
@@ -143,14 +143,14 @@ test_that("Grouped frequency table is displayed correctly", {
     desc <- jmv::descriptives(data = df, vars = "dep", splitBy = "group", freq = TRUE)
     freq <- desc$frequencies[[1]]$asDF
 
-    expect_equal(as.character(rep(1:3, each=3)), freq[[1]])
-    expect_equal(rep(letters[1:3], times=3), freq[[2]])
-    expect_equal(c(13, 10, 10, 7, 15, 6, 13, 10, 16), freq$counts)
-    expect_equal(c(0.13, 0.1, 0.1, 0.07, 0.15, 0.06, 0.13, 0.1, 0.16), freq$pc)
-    expect_equal(c(0.13, 0.23, 0.33, 0.4, 0.55, 0.61, 0.74, 0.84, 1), freq$cumpc)
+    testthat::expect_equal(as.character(rep(1:3, each=3)), freq[[1]])
+    testthat::expect_equal(rep(letters[1:3], times=3), freq[[2]])
+    testthat::expect_equal(c(13, 10, 10, 7, 15, 6, 13, 10, 16), freq$counts)
+    testthat::expect_equal(c(0.13, 0.1, 0.1, 0.07, 0.15, 0.06, 0.13, 0.1, 0.16), freq$pc)
+    testthat::expect_equal(c(0.13, 0.23, 0.33, 0.4, 0.55, 0.61, 0.74, 0.84, 1), freq$cumpc)
 })
 
-test_that('descriptives works old scenario', {
+testthat::test_that('descriptives works old scenario', {
 
     w <- as.factor(rep(c("1", "2","3"), each=4))
     x <- as.factor(rep(c("a", "b","c"), 4))
@@ -166,20 +166,20 @@ test_that('descriptives works old scenario', {
     descr <- desc$descriptives$asDF
 
     # Test frequency table numerical values
-    expect_equal(c(2, 1, 1, 1, 2, 1, 1, 1, 2), freq$counts)
+    testthat::expect_equal(c(2, 1, 1, 1, 2, 1, 1, 1, 2), freq$counts)
 
     # Test descriptives table numerical values
-    expect_equal(2.619, descr$`y[seKurtb]`, tolerance = 1e-3)
-    expect_equal(-1.289, descr$`z[kurtc]`, tolerance = 1e-3)
-    expect_equal(1, descr$`z[missinga]`, tolerance = 1e-3)
-    expect_equal(5.750, descr$`y[meana]`, tolerance = 1e-3)
-    expect_equal(-2, descr$`z[modeb]`, tolerance = 1e-3)
-    expect_equal(4, descr$`y[mina]`, tolerance = 1e-3)
-    expect_equal(2.25, descr$`y[perc1c]`, tolerance = 1e-3)
+    testthat::expect_equal(2.619, descr$`y[seKurtb]`, tolerance = 1e-3)
+    testthat::expect_equal(-1.289, descr$`z[kurtc]`, tolerance = 1e-3)
+    testthat::expect_equal(1, descr$`z[missinga]`, tolerance = 1e-3)
+    testthat::expect_equal(5.750, descr$`y[meana]`, tolerance = 1e-3)
+    testthat::expect_equal(-2, descr$`z[modeb]`, tolerance = 1e-3)
+    testthat::expect_equal(4, descr$`y[mina]`, tolerance = 1e-3)
+    testthat::expect_equal(2.25, descr$`y[perc1c]`, tolerance = 1e-3)
 
 })
 
-test_that('histogram is created for nominal numeric variable', {
+testthat::test_that('histogram is created for nominal numeric variable', {
 
     set.seed(1337)
     data <- data.frame(
@@ -191,7 +191,7 @@ test_that('histogram is created for nominal numeric variable', {
 
     desc <- jmv::descriptives(data, c('a1', 'a2'), hist=TRUE)
 
-    expect_true(desc$plots[[2]]$.render())
+    testthat::expect_true(desc$plots[[2]]$.render())
 })
 
 testthat::test_that("No error is thrown when an empty factor is used as variable", {
@@ -214,3 +214,56 @@ testthat::test_that('Sensible error message is provided when splitBy var contain
         "The 'split by' variable 'group' contains no data."
     )
 })
+
+testthat::test_that('Extreme values table works', {
+    df <- data.frame(
+        numeric = rnorm(100),
+        ordinal = sample(1:7, 100, replace = TRUE),
+        character = factor(sample(letters[1:7], 100, replace = TRUE))
+    )
+
+    extremeN <- 5
+
+    r <- jmv::descriptives(
+        data=df, vars=c("numeric", "ordinal", "character"), extreme=TRUE, extremeN=extremeN
+    )
+
+    e1 <- r$extremeValues[[1]]$asDF
+    lowest <- head(df[order(df$numeric),], topN)
+    highest <- head(df[order(-df$numeric),], topN)
+    casesExpected <- c(rownames(highest), rownames(lowest))
+    valuesExpected <- c(highest$numeric, lowest$numeric)
+
+    testthat::expect_equal(e1$row, casesExpected)
+    testthat::expect_equal(e1$value, valuesExpected)
+
+    e2 <- r$extremeValues[[2]]$asDF
+    lowest <- head(df[order(df$ordinal),], topN)
+    highest <- head(df[order(-df$ordinal),], topN)
+    casesExpected <- c(rownames(highest), rownames(lowest))
+    valuesExpected <- c(highest$ordinal, lowest$ordinal)
+
+    testthat::expect_equal(e2$row, casesExpected)
+    testthat::expect_equal(e2$value, valuesExpected)
+
+    e3 <- r$extremeValues[[3]]$asDF
+    testthat::expect_true(all(is.na(e3)))
+})
+
+testthat::test_that('Extreme values provides note if number of cases is lower than extremeN', {
+    df <- data.frame(x = c(1.1, 2.3, 3.1))
+    extremeN <- 5
+
+    r <- jmv::descriptives(data=df, vars="x", extreme=TRUE, extremeN=extremeN)
+    e <- r$extremeValues[[1]]
+
+    testthat::expect_match(
+        e$notes$insufficientData$note,
+        "Number of requested extreme values is higher than the number of rows in the data."
+    )
+
+    eDf <- e$asDF
+    testthat::expect_equal(eDf$row, c("3", "2", "1", NA, NA, "1", "2", "3", NA, NA))
+    testthat::expect_equal(eDf$value, c(3.1, 2.3, 1.1, NA, NA, 1.1, 2.3, 3.1, NA, NA))
+})
+


### PR DESCRIPTION
Table shows the extremest values (highest and lowest) of a numeric variable. The number of required extreme values can be defined by the user.

Important: this implementation ignores the grouping variable

Closes #168 

The implementation looks as follows:
<img width="1375" alt="Screenshot 2022-08-21 at 13 22 28" src="https://user-images.githubusercontent.com/4669197/185788643-86929040-f563-4ceb-abff-ae5c64d49aa6.png">
