### PR TITLE
Fixes anova contrast error

### DIFF
--- a/R/ancova.b.R
+++ b/R/ancova.b.R
@@ -542,7 +542,7 @@ ancovaClass <- R6::R6Class(
 
                 for (i in seq_along(labels)) {
                     label <- labels[[i]]
-                    name <- paste0(var, i)
+                    name <- paste0(jmvcore::composeTerm(var), i)
                     table$setRow(rowNo=i, list(
                         contrast=label,
                         est=contrResults[name, "Estimate"],

--- a/tests/testthat/testanova.R
+++ b/tests/testthat/testanova.R
@@ -63,3 +63,46 @@ testthat::test_that('Provide error message when dep variable contains infinte va
         "Dependent variable 'dep' contains infinite values"
     )
 })
+
+testthat::test_that("Contrasts work", {
+    df <- data.frame(
+        dep = c(1,6,3,2,6,2,3,1,9,2),
+        var = factor(rep(1:2, length.out = 10))
+    )
+
+    contrasts <- list(
+        list(var="var", type="deviation")
+    )
+
+    r <- jmv::ANOVA(data=df,dep="dep", factors=c("var"), contrasts=contrasts)
+
+    contr <- r$contrasts[[1]]$asDF
+
+    testthat::expect_equal(contr$est, -0.9)
+    testthat::expect_equal(contr$se, 0.825, tolerance=1e-3)
+    testthat::expect_equal(contr$t, -1.091, tolerance=1e-3)
+    testthat::expect_equal(contr$p, 0.307, tolerance=1e-3)
+})
+
+
+testthat::test_that("Contrasts work with special characters in variable name", {
+    df <- data.frame(
+        dep = c(1,6,3,2,6,2,3,1,9,2),
+        var = factor(rep(1:2, length.out = 10))
+    )
+    names(df) <- c("dep~A", "var A")
+
+    contrasts <- list(
+        list(var="var A", type="deviation")
+    )
+
+    r <- jmv::ANOVA(data=df,dep="dep~A", factors=c("var A"), contrasts=contrasts)
+
+    contr <- r$contrasts[[1]]$asDF
+
+    testthat::expect_equal(contr$est, -0.9)
+    testthat::expect_equal(contr$se, 0.825, tolerance=1e-3)
+    testthat::expect_equal(contr$t, -1.091, tolerance=1e-3)
+    testthat::expect_equal(contr$p, 0.307, tolerance=1e-3)
+})
+

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -229,8 +229,8 @@ testthat::test_that('Extreme values table works', {
     )
 
     e1 <- r$extremeValues[[1]]$asDF
-    lowest <- head(df[order(df$numeric),], topN)
-    highest <- head(df[order(-df$numeric),], topN)
+    lowest <- head(df[order(df$numeric),], extremeN)
+    highest <- head(df[order(-df$numeric),], extremeN)
     casesExpected <- c(rownames(highest), rownames(lowest))
     valuesExpected <- c(highest$numeric, lowest$numeric)
 
@@ -238,8 +238,8 @@ testthat::test_that('Extreme values table works', {
     testthat::expect_equal(e1$value, valuesExpected)
 
     e2 <- r$extremeValues[[2]]$asDF
-    lowest <- head(df[order(df$ordinal),], topN)
-    highest <- head(df[order(-df$ordinal),], topN)
+    lowest <- head(df[order(df$ordinal),], extremeN)
+    highest <- head(df[order(-df$ordinal),], extremeN)
     casesExpected <- c(rownames(highest), rownames(lowest))
     valuesExpected <- c(highest$ordinal, lowest$ordinal)
 


### PR DESCRIPTION
There was an issue with ANOVA contrasts when using factors with special characters or spaces in the variable name. This PR fixes this.

I also added a small fix for an error in the descriptives tests

Fixes jamovi/jamovi#1236