### PR TITLE
Make emmeans more robust for complex models

### DIFF
--- a/R/linreg.b.R
+++ b/R/linreg.b.R
@@ -351,9 +351,15 @@ linRegClass <- R6::R6Class(
                             emmeans::emm_options(sep=",", parens="a^", cov.keep=1)
 
                             mm <- try(
-                                emmeans::emmeans(model, formula, cov.reduce=FUN,
-                                                 options=list(level=self$options$ciWidthEmm / 100),
-                                                 weights=weights, data=self$dataProcessed),
+                                emmeans::emmeans(
+                                    model,
+                                    formula,
+                                    cov.reduce = FUN,
+                                    options = list(level=self$options$ciWidthEmm / 100),
+                                    weights = weights,
+                                    data = self$dataProcessed,
+                                    non.nuis = all.vars(formula),
+                                ),
                                 silent = TRUE
                             )
 
@@ -1041,6 +1047,9 @@ linRegClass <- R6::R6Class(
             return(p)
         },
         .prepareEmmPlots = function() {
+            if (! self$options$emmPlots)
+                return()
+
             covs <- self$options$covs
             dep <- self$options$dep
 
@@ -1074,14 +1083,18 @@ linRegClass <- R6::R6Class(
                                         levels(d[[ termB64[k] ]]) <- c('-1SD', 'Mean', '+1SD')
                                     }
                                 } else {
-                                    d[[ termB64[k] ]] <- factor(jmvcore::fromB64(d[[ termB64[k] ]]),
-                                                                jmvcore::fromB64(levels(d[[ termB64[k] ]])))
+                                    d[[ termB64[k] ]] <- factor(
+                                        jmvcore::fromB64(d[[ termB64[k] ]]),
+                                        jmvcore::fromB64(levels(d[[ termB64[k] ]]))
+                                    )
                                 }
                             }
                         }
 
-                        names <- list('x'=termB64[1], 'y'='emmean', 'lines'=termB64[2],
-                                      'plots'=termB64[3], 'lower'='lower.CL', 'upper'='upper.CL')
+                        names <- list(
+                            'x'=termB64[1], 'y'='emmean', 'lines'=termB64[2], 'plots'=termB64[3],
+                            'lower'='lower.CL', 'upper'='upper.CL'
+                        )
                         names <- lapply(names, function(x) if (is.na(x)) NULL else x)
 
                         labels <- list('x'=term[1], 'y'=dep, 'lines'=term[2], 'plots'=term[3])


### PR DESCRIPTION
Previously, the reference grid that is used to compute the estimated marginal means grew exponentially with the number of predictors in the model. As a consequence, the reference grid could grow so big that the emmeans analysis threw an error.

This commit marks all predictors that are not of interest for the emmeans plot/table as so-called "nuisance parameters", so that the reference grid averages over all these parameters and thus remains small in size, even when the number of parameters grow.

See https://cran.r-project.org/web/packages/emmeans/vignettes/messy-data.html

Closes jamovi/jamovi#1259