### PR TITLE
Update 00refs.yaml

### DIFF
--- a/jamovi/00refs.yaml
+++ b/jamovi/00refs.yaml
@@ -91,7 +91,7 @@ refs:
 
     nnet:
         type: 'software'
-        author: Ripley, B., Venables W.
+        author: Ripley, B., Venables, W.
         year: 2016
         title: 'nnet: Feed-Forward Neural Networks and Multinomial Log-Linear Models'
         publisher: '[R package]. Retrieved from https://cran.r-project.org/package=nnet'
@@ -99,7 +99,7 @@ refs:
 
     MASS:
         type: 'software'
-        author: Ripley, B., Venables W., Bates, D. M., Hornik, K., Gebhardt, A., & Firth, D.
+        author: Ripley, B., Venables, W., Bates, D. M., Hornik, K., Gebhardt, A., & Firth, D.
         year: 2018
         title: "MASS: Support Functions and Datasets for Venables and Ripley's MASS"
         publisher: '[R package]. Retrieved from https://cran.r-project.org/package=MASS'
@@ -115,7 +115,7 @@ refs:
 
     vcdExtra:
         type: 'software'
-        author: Friendly M., Turner, H., Zeileis, A., Murdoch, D., & Firth, D.
+        author: Friendly, M., Turner, H., Zeileis, A., Murdoch, D., & Firth, D.
         year: 2017
         title: "vcdExtra: 'vcd' Extensions and Additions"
         publisher: '[R package]. Retrieved from https://cran.r-project.org/package=vcdExtra'


### PR DESCRIPTION
Corrected typos. The missing commas cause the latexify-script to break.