### PR TITLE
tTests: always show hypothesis footnote

### DIFF
--- a/R/ttestis.b.R
+++ b/R/ttestis.b.R
@@ -521,7 +521,8 @@ ttestISClass <- R6::R6Class(
             else if (hypothesis == 'twoGreater')
                 table$setNote("hyp", jmvcore::format("H\u2090 \u03BC\u2009<sub>{}</sub> < \u03BC\u2009<sub>{}</sub>", groups[1], groups[2]))
             else
-                table$setNote("hyp", NULL)
+                table$setNote("hyp", jmvcore::format("H\u2090 \u03BC\u2009<sub>{}</sub> \u2260 \u03BC\u2009<sub>{}</sub>", groups[1], groups[2]))
+
         },
         .desc=function(image, ggtheme, theme, ...) {
 

--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -282,9 +282,7 @@ ttestOneSClass <- R6::R6Class(
             table$getColumn('ciues[wilc]')$setSuperTitle(ciTitleES)
             table$getColumn('ciles[wilc]')$setSuperTitle(ciTitleES)
 
-            if (hypothesis == 'dt' && testValue == 0)
-                table$setNote("hyp", NULL)
-            else if (hypothesis == 'dt')
+            if (hypothesis == 'dt')
                 table$setNote("hyp", jmvcore::format("H\u2090 \u03BC \u2260 {}", testValue))
             else if (hypothesis == 'gt')
                 table$setNote("hyp", jmvcore::format("H\u2090 \u03BC > {}", testValue))

--- a/R/ttestps.b.R
+++ b/R/ttestps.b.R
@@ -332,7 +332,10 @@ ttestPSClass <- R6::R6Class(
                     jmvcore::format("H\u2090 \u03BC\u2009<sub>{}</sub> < 0", .("Measure 1 - Measure 2"))
                 )
             } else {
-                ttestTable$setNote("hyp", NULL)
+                ttestTable$setNote(
+                    "hyp",
+                    jmvcore::format("H\u2090 \u03BC\u2009<sub>{}</sub> \u2260 0", .("Measure 1 - Measure 2"))
+                )
             }
 
             pairs <- self$options$pairs


### PR DESCRIPTION
Previously, the hypothesis footnote was not shown when the hypothesis was the default one. However, I think it's good to always show this in the main table so that the output is more self contained.