### PR TITLE
Update for the correlation of text-type ordinal measures

### DIFF
--- a/R/corrmatrix.b.R
+++ b/R/corrmatrix.b.R
@@ -14,7 +14,7 @@ corrMatrixClass <- R6::R6Class(
         for (i in seq_along(vars)) {
             var <- vars[[i]]
 
-            if(is.ordered(self$data[[var]]) && self$options$pearson)
+            if (is.factor(self$data[[var]]) && self$options$pearson)
                 mtord <- TRUE
 
             matrix$addColumn(name=paste0(var, '[r]'), title=var,

--- a/R/corrmatrix.b.R
+++ b/R/corrmatrix.b.R
@@ -14,7 +14,7 @@ corrMatrixClass <- R6::R6Class(
         for (i in seq_along(vars)) {
             var <- vars[[i]]
 
-            if(is.factor(self$data[[var]]) && self$options$pearson)
+            if(is.ordered(self$data[[var]]) && self$options$pearson)
                 mtord <- TRUE
 
             matrix$addColumn(name=paste0(var, '[r]'), title=var,
@@ -128,10 +128,10 @@ corrMatrixClass <- R6::R6Class(
                     colVarName <- vars[[j]]
                     colVar <- jmvcore::toNumeric(self$data[[colVarName]])
 
-                    if(is.factor(self$data[[rowVarName]]) || is.factor(self$data[[colVarName]]))
+                    if(is.ordered(self$data[[rowVarName]]) || is.ordered(self$data[[colVarName]]))
                         mtord <- TRUE
                     else
-                        mtord <- TRUE
+                        mtord <- FALSE
 
                     result <- private$.test(rowVar, colVar, hyp, mtord)
 

--- a/R/corrmatrix.h.R
+++ b/R/corrmatrix.h.R
@@ -34,7 +34,8 @@ corrMatrixOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "continuous",
                     "ordinal"),
                 permitted=list(
-                    "numeric"))
+                    "numeric",
+                    "factor"))
             private$..pearson <- jmvcore::OptionBool$new(
                 "pearson",
                 pearson,

--- a/jamovi/corrmatrix.a.yaml
+++ b/jamovi/corrmatrix.a.yaml
@@ -68,6 +68,7 @@ options:
         - ordinal
       permitted:
         - numeric
+        - factor
       description:
           ui: >
             the variables of interest.


### PR DESCRIPTION
Nonparametric correlation is possible if the ordinal variable is also a text-type measure.
If at least one variable is ordinal with the Pearson correlation option, returns NaN and a footnote explains this.