### PR TITLE
CFA: catch unclear error message 

### DIFF
--- a/R/cfa.b.R
+++ b/R/cfa.b.R
@@ -3,13 +3,63 @@
 cfaClass <- R6::R6Class(
     "cfaClass",
     inherit = cfaBase,
+    #### Active bindings ----
+    active = list(
+        dataProcessed = function() {
+            if (is.null(private$.dataProcessed))
+                private$.dataProcessed <- private$.cleanData()
+
+            return(private$.dataProcessed)
+        },
+        model = function() {
+            if (is.null(private$.model))
+                private$.model <- private$.computeModel()
+
+            return(private$.model)
+        },
+        estimates = function() {
+            if (is.null(private$.estimates)) {
+                private$.estimates <- lavaan::parameterestimates(
+                    self$model, standardized = TRUE, level = self$options$ciWidth / 100
+                )
+            }
+
+            return(private$.estimates)
+        },
+        fitMeasures = function() {
+            if (is.null(private$.fitMeasures))
+                private$.fitMeasures <- lavaan::fitMeasures(self$model)
+
+            return(private$.fitMeasures)
+        },
+        residuals = function() {
+            if (is.null(private$.residuals))
+                private$.residuals <- lavaan::residuals(self$model, type = "cor")[[2]]
+
+            return(private$.residuals)
+        },
+        modIndices = function() {
+            if (is.null(private$.modIndices)) {
+                private$.modIndices <- lavaan::modificationIndices(
+                    self$model, sort.=FALSE, minimum.value=0
+                )
+            }
+
+            return(private$.modIndices)
+        }
+    ),
     private = list(
         #### Member variables ----
         estResCov = NULL,
+        .dataProcessed = NULL,
+        .model = NULL,
+        .estimates = NULL,
+        .fitMeasures = NULL,
+        .residuals = NULL,
+        .modIndices = NULL,
 
         #### Init + run functions ----
         .init = function() {
-
             private$.initFactorLoadingsTable()
             private$.initFactorCovTable()
             private$.initFactorInterceptTable()
@@ -21,51 +71,39 @@ cfaClass <- R6::R6Class(
 
             syntax <- private$.lavaanify(FALSE)
             self$results$.setModelSyntax(syntax)
-
         },
         .run = function() {
-
-            ready <- private$.ready()
-
-            if (ready) {
-
-                data <- private$.cleanData()
-                results <- private$.compute(data)
-
-                private$.populateFactorLoadingsTable(results)
-                private$.populateFactorCovTable(results)
-                private$.populateFactorInterceptTable(results)
-                private$.populateResCovTable(results)
-                private$.populateResInterceptTable(results)
-                private$.populateFitMeasuresTable(results)
-                private$.populateTestTable(results)
-                private$.populateCorResTable(results)
-                private$.populateResCovModTable(results)
-                private$.populateFactorLoadingsModTable(results)
-                private$.preparePathDiagram(results)
-
+            if (private$.ready()) {
+                private$.populateFactorLoadingsTable()
+                private$.populateFactorCovTable()
+                private$.populateFactorInterceptTable()
+                private$.populateResCovTable()
+                private$.populateResInterceptTable()
+                private$.populateFitMeasuresTable()
+                private$.populateTestTable()
+                private$.populateCorResTable()
+                private$.populateResCovModTable()
+                private$.populateFactorLoadingsModTable()
+                private$.preparePathDiagram()
             }
         },
 
         #### Compute results ----
-        .compute = function(data) {
-
+        .computeModel = function() {
             model <- private$.lavaanify()
             std.lv <- self$options$constrain == "facVar"
             missing <- self$options$miss
 
             suppressWarnings({
-
-                fit <- lavaan::cfa(model = model, data=data, std.lv=std.lv, missing=missing, meanstructure=TRUE)
-                estimates <- lavaan::parameterestimates(fit, standardized = TRUE, level = self$options$ciWidth / 100)
-                fitMeasures <- lavaan::fitMeasures(fit)
-                residuals <- lavaan::residuals(fit, type = "cor")[[2]]
-                modIndices <- lavaan::modificationIndices(fit, sort.=FALSE, minimum.value=0)
-
-            }) # suppressWarnings
-
-            return(list('fit'=fit, 'estimates'=estimates, 'fitMeasures'=fitMeasures,
-                        'residuals'=residuals, 'modIndices'=modIndices))
+                fit <- lavaan::cfa(
+                    model=model,
+                    data=self$dataProcessed,
+                    std.lv=std.lv,
+                    missing=missing,
+                    meanstructure=TRUE
+                )
+            })
+            return(fit)
         },
 
         #### Init tables/plots functions ----
@@ -329,12 +367,11 @@ cfaClass <- R6::R6Class(
         },
 
         #### Populate tables ----
-        .populateFactorLoadingsTable = function(results) {
-
+        .populateFactorLoadingsTable = function() {
             table <- self$results$factorLoadings
 
             factors <- self$options$factors
-            r <- results$estimates
+            r <- self$estimates
 
             rowNo <- 1
 
@@ -369,12 +406,12 @@ cfaClass <- R6::R6Class(
                 }
             }
         },
-        .populateFactorCovTable = function(results) {
+        .populateFactorCovTable = function() {
 
             table <- self$results$factorEst$factorCov
             factors <- sapply(self$options$factors, function(x) x$label)
 
-            r <- results$estimates
+            r <- self$estimates
             rowNo <- 1
 
             for (i in 1:length(factors)) {
@@ -405,12 +442,12 @@ cfaClass <- R6::R6Class(
                 }
             }
         },
-        .populateFactorInterceptTable = function(results) {
+        .populateFactorInterceptTable = function() {
 
             table <- self$results$factorEst$factorIntercept
             factors <- sapply(self$options$factors, function(x) x$label)
 
-            r <- results$estimates
+            r <- self$estimates
 
             # for (i in 1:length(factors)) {
             #
@@ -430,12 +467,12 @@ cfaClass <- R6::R6Class(
             #         table$setRow(rowNo=i, values=row)
             # }
         },
-        .populateResCovTable = function(results) {
+        .populateResCovTable = function() {
 
             table <- self$results$resEst$resCov
             vars <- unique(unlist(lapply(self$options$factors, function(x) x$vars)))
 
-            r <- results$estimates
+            r <- self$estimates
             varsMatrix <- private$estResCov
             rowNo <- 1
 
@@ -467,12 +504,12 @@ cfaClass <- R6::R6Class(
                 }
             }
         },
-        .populateResInterceptTable = function(results) {
+        .populateResInterceptTable = function() {
 
             table <- self$results$resEst$resIntercept
             vars <- unique(unlist(lapply(self$options$factors, function(x) x$vars)))
 
-            r <- results$estimates
+            r <- self$estimates
 
             for (i in 1:length(vars)) {
 
@@ -492,10 +529,10 @@ cfaClass <- R6::R6Class(
                 table$setRow(rowNo=i, values=row)
             }
         },
-        .populateFitMeasuresTable = function(results) {
+        .populateFitMeasuresTable = function() {
 
             table <- self$results$modelFit$fitMeasures
-            r <- results$fitMeasures
+            r <- self$fitMeasures
 
             row <- list()
             row[['cfi']] <- as.numeric(r['cfi'])
@@ -509,10 +546,10 @@ cfaClass <- R6::R6Class(
 
             table$setRow(rowNo=1, values=row)
         },
-        .populateTestTable = function(results) {
+        .populateTestTable = function() {
 
             table <- self$results$modelFit$test
-            r <- results$fitMeasures
+            r <- self$fitMeasures
 
             row <- list()
             row[['chi']] <- as.numeric(r['chisq'])
@@ -521,13 +558,13 @@ cfaClass <- R6::R6Class(
 
             table$setRow(rowNo=1, values=row)
         },
-        .populateCorResTable = function(results) {
+        .populateCorResTable = function() {
 
             table <- self$results$modelPerformance$corRes
             vars <- unique(unlist(lapply(self$options$factors, function(x) x$vars)))
             highlight <- self$options$hlCorRes
 
-            r <- results$residuals
+            r <- self$residuals
 
             for (i in 1:(length(vars) - 1)) {
                 row <- list()
@@ -544,13 +581,13 @@ cfaClass <- R6::R6Class(
                     table$addFormat(col=highVar, rowNo=i, Cell.NEGATIVE)
             }
         },
-        .populateResCovModTable = function(results) {
+        .populateResCovModTable = function() {
 
             table <- self$results$modelPerformance$modIndices$resCovMod
             vars <- unique(unlist(lapply(self$options$factors, function(x) x$vars)))
             highlight <- self$options$hlMI
 
-            r <- results$modIndices
+            r <- self$modIndices
 
             varsMatrix <- private$estResCov
             varsMatrix <- abs(varsMatrix - 1)
@@ -586,14 +623,14 @@ cfaClass <- R6::R6Class(
                     table$addFormat(col=highVar, rowNo=i, Cell.NEGATIVE)
             }
         },
-        .populateFactorLoadingsModTable = function(results) {
+        .populateFactorLoadingsModTable = function() {
 
             table <- self$results$modelPerformance$modIndices$factorLoadingsMod
             vars <- unique(unlist(lapply(self$options$factors, function(x) x$vars)))
             factors <- sapply(self$options$factors, function(x) x$label)
             highlight <- self$options$hlMI
 
-            r <- results$modIndices
+            r <- self$modIndices
 
             for (i in seq_along(vars)) {
 
@@ -629,9 +666,9 @@ cfaClass <- R6::R6Class(
         },
 
         #### Plot functions ----
-        .preparePathDiagram = function(results) {
+        .preparePathDiagram = function() {
 
-            fit <- results$fit
+            fit <- self$model
 
             fit@ParTable$rhs <- jmvcore::fromB64(fit@ParTable$rhs)
             fit@ParTable$lhs <- jmvcore::fromB64(fit@ParTable$lhs)

--- a/R/errors.R
+++ b/R/errors.R
@@ -79,3 +79,18 @@ exceptions = list(
     "dataError" = "dataError"
 )
 
+cfaErrors = list(
+    list(
+        originalMessage = paste0(
+            'invalid object for slot "fx.group" in class "Fit": got class "NULL", should be or',
+            ' extend class "numeric"'
+        ),
+        message = "Model dit not converge",
+        class = exceptions$modelError
+    ),
+    list(
+        originalMessage = 'lavaan ERROR: fit measures not available if model did not converge',
+        message = "Model dit not converge",
+        class = exceptions$modelError
+    )
+)

--- a/tests/testthat/testcfa.R
+++ b/tests/testthat/testcfa.R
@@ -278,3 +278,23 @@ testthat::test_that('All options in the cfa work (sunny)', {
         modIndResCov[['XeDk']], tolerance = 1e-3
     )
 })
+
+testthat::test_that('Human readable error message is thrown when model does not converge', {
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+
+    nVars <- 20
+    nCases <- 10
+
+    data <- list()
+    for (i in 1:nVars)
+        data[[paste0("w",i)]] <- rnorm(nCases)
+    data <- as.data.frame(data)
+
+    factors <- list(list(label='factor_1', vars=paste0("w", 1:nVars)))
+
+    testthat::expect_error(
+        jmv::cfa(data = data, factors = factors, resCov = NULL, stdEst = TRUE, corRes = TRUE),
+        class = exceptions$modelError
+    )
+})


### PR DESCRIPTION
Error message indicates that model did not converge, but gives a non-comprehensible message instead.
This commit, introduces a way to catch the error message, and throw a more user-friendly error
message instead.

Please give this one a thorough review @jonathon-love because I do introduce some new way of error handling here.

Fixes jamovi/jamovi#1204
Fixes jamovi/jamovi#1292