### PR TITLE
corrMatrix: add degrees of freedom to output

### DIFF
--- a/R/corrmatrix.b.R
+++ b/R/corrmatrix.b.R
@@ -15,6 +15,8 @@ corrMatrixClass <- R6::R6Class(
 
             matrix$addColumn(name=paste0(var, '[r]'), title=var,
                 type='number', format='zto', visible='(pearson)')
+            matrix$addColumn(name=paste0(var, '[rdf]'), title=var,
+                type='integer', visible='(pearson && sig)')
             matrix$addColumn(name=paste0(var, '[rp]'), title=var,
                 type='number', format='zto,pvalue', visible='(pearson && sig)')
             matrix$addColumn(name=paste0(var, '[rciu]'), title=var,
@@ -23,6 +25,8 @@ corrMatrixClass <- R6::R6Class(
                 type='number', format='zto', visible='(pearson && ci)')
             matrix$addColumn(name=paste0(var, '[rho]'), title=var,
                 type='number', format='zto', visible='(spearman)')
+            matrix$addColumn(name=paste0(var, '[rhodf]'), title=var,
+                type='integer', visible='(spearman && sig)')
             matrix$addColumn(name=paste0(var, '[rhop]'), title=var,
                 type='number', format='zto,pvalue', visible='(spearman && sig)')
             matrix$addColumn(name=paste0(var, '[tau]'), title=var,
@@ -41,10 +45,12 @@ corrMatrixClass <- R6::R6Class(
             for (j in seq(i, nVars)) {
                 v <- vars[[j]]
                 values[[paste0(v, '[r]')]] <- ''
+                values[[paste0(v, '[rdf]')]] <- ''
                 values[[paste0(v, '[rp]')]] <- ''
                 values[[paste0(v, '[rciu]')]] <- ''
                 values[[paste0(v, '[rcil]')]] <- ''
                 values[[paste0(v, '[rho]')]] <- ''
+                values[[paste0(v, '[rhodf]')]] <- ''
                 values[[paste0(v, '[rhop]')]] <- ''
                 values[[paste0(v, '[tau]')]] <- ''
                 values[[paste0(v, '[taup]')]] <- ''
@@ -52,10 +58,12 @@ corrMatrixClass <- R6::R6Class(
             }
 
             values[[paste0(var, '[r]')]] <- '\u2014'
+            values[[paste0(var, '[rdf]')]] <- '\u2014'
             values[[paste0(var, '[rp]')]] <- '\u2014'
             values[[paste0(var, '[rciu]')]] <- '\u2014'
             values[[paste0(var, '[rcil]')]] <- '\u2014'
             values[[paste0(var, '[rho]')]] <- '\u2014'
+            values[[paste0(var, '[rhodf]')]] <- '\u2014'
             values[[paste0(var, '[rhop]')]] <- '\u2014'
             values[[paste0(var, '[tau]')]] <- '\u2014'
             values[[paste0(var, '[taup]')]] <- '\u2014'
@@ -131,7 +139,11 @@ corrMatrixClass <- R6::R6Class(
                     values[[paste0(colVarName, '[taup]')]] <- result$taup
                     values[[paste0(colVarName, '[taup]')]] <- result$taup
 
-                    values[[paste0(colVarName, '[n]')]] <- sum( ! (is.na(colVar) | is.na(rowVar)))
+                    n <- sum( ! (is.na(colVar) | is.na(rowVar)))
+                    df <- n - 2
+                    values[[paste0(colVarName, '[n]')]] <- n
+                    values[[paste0(colVarName, '[rdf]')]] <- df
+                    values[[paste0(colVarName, '[rhodf]')]] <- df
 
                     matrix$setRow(rowNo=i, values)
 

--- a/R/corrmatrix.h.R
+++ b/R/corrmatrix.h.R
@@ -171,6 +171,19 @@ corrMatrixResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                         `content`="Pearson's r", 
                         `visible`="(pearson && (sig || spearman || kendall || ci || n))"),
                     list(
+                        `name`=".name[rdf]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="($key)", 
+                        `combineBelow`=TRUE, 
+                        `visible`="(pearson && sig)"),
+                    list(
+                        `name`=".stat[rdf]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="df", 
+                        `visible`="(pearson && sig)"),
+                    list(
                         `name`=".name[rp]", 
                         `title`="", 
                         `type`="text", 
@@ -222,6 +235,19 @@ corrMatrixResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                         `type`="text", 
                         `content`="Spearman's rho", 
                         `visible`="(spearman && (sig || pearson || kendall || n))"),
+                    list(
+                        `name`=".name[rhodf]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="($key)", 
+                        `combineBelow`=TRUE, 
+                        `visible`="(spearman && sig)"),
+                    list(
+                        `name`=".stat[rhodf]", 
+                        `title`="", 
+                        `type`="text", 
+                        `content`="df", 
+                        `visible`="(spearman && sig)"),
                     list(
                         `name`=".name[rhop]", 
                         `title`="", 

--- a/jamovi/corrmatrix.r.yaml
+++ b/jamovi/corrmatrix.r.yaml
@@ -28,6 +28,19 @@ items:
             content: Pearson's r
             visible: (pearson && (sig || spearman || kendall || ci || n))
 
+          - name: .name[rdf]
+            title: ""
+            type: text
+            content: ($key)
+            combineBelow: true
+            visible: (pearson && sig)
+
+          - name: .stat[rdf]
+            title: ""
+            type: text
+            content: df
+            visible: (pearson && sig)
+
           - name: .name[rp]
             title: ""
             type: text
@@ -79,6 +92,19 @@ items:
             type: text
             content: Spearman's rho
             visible: (spearman && (sig || pearson || kendall || n))
+
+          - name: .name[rhodf]
+            title: ""
+            type: text
+            content: ($key)
+            combineBelow: true
+            visible: (spearman && sig)
+
+          - name: .stat[rhodf]
+            title: ""
+            type: text
+            content: df
+            visible: (spearman && sig)
 
           - name: .name[rhop]
             title: ""

--- a/tests/testthat/testcorrmatrix.R
+++ b/tests/testthat/testcorrmatrix.R
@@ -31,6 +31,11 @@ testthat::test_that('All options in the corrMatrix work (sunny)', {
         -0.647, as.numeric(corTable$getCell(rowKey="var 3", "var 2[r]")$value), tolerance = 1e-3
     )
 
+    # Test Pearson's r degrees of freedom
+    testthat::expect_equal(9, as.numeric(corTable$getCell(rowKey="var 2", "var 1[rdf]")$value))
+    testthat::expect_equal(11, as.numeric(corTable$getCell(rowKey="var 3", "var 1[rdf]")$value))
+    testthat::expect_equal(9, as.numeric(corTable$getCell(rowKey="var 3", "var 2[rdf]")$value))
+
     # Test Pearson's r p-value
     testthat::expect_equal(
         0.807, as.numeric(corTable$getCell(rowKey="var 2", "var 1[rp]")$value), tolerance = 1e-3
@@ -74,6 +79,11 @@ testthat::test_that('All options in the corrMatrix work (sunny)', {
     testthat::expect_equal(
         -0.569, as.numeric(corTable$getCell(rowKey="var 3", "var 2[rho]")$value), tolerance = 1e-3
     )
+
+    # Test Spearman's rho degrees of freedom
+    testthat::expect_equal(9, as.numeric(corTable$getCell(rowKey="var 2", "var 1[rhodf]")$value))
+    testthat::expect_equal(11, as.numeric(corTable$getCell(rowKey="var 3", "var 1[rhodf]")$value))
+    testthat::expect_equal(9, as.numeric(corTable$getCell(rowKey="var 3", "var 2[rhodf]")$value))
 
     # Test Spearman's rho p-value
     testthat::expect_equal(


### PR DESCRIPTION
Added degrees of freedom for both Pearson's r and
Spearman's rho. The dfs are added if the "report
significance" option is checked, so that the user
has all information needed to report the actual test results.