### PR TITLE
tTestOnes: fix rank biserial effect size

### DIFF
--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -120,7 +120,7 @@ ttestOneSClass <- R6::R6Class(
 
                     if ( ! isError(res)) {
 
-                        nTies <- sum(column == 0)
+                        nTies <- sum(column == testValue)
                         totalRankSum <- ((n-nTies) * ((n-nTies) + 1)) / 2
                         biSerial <- (2 * (res$statistic / totalRankSum)) - 1
 

--- a/tests/testthat/testttestones.R
+++ b/tests/testthat/testttestones.R
@@ -78,3 +78,15 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     testthat::expect_equal(0.234, ttestTable[['p[wilc]']], tolerance = 1e-3)
     testthat::expect_equal(0.5, ttestTable[['es[wilc]']])
 })
+
+testthat::test_that('Matched rank biserial correlation works with non zero test value', {
+    df <- data.frame(x = c(1, 5, 3, 4, 4, 2, 3, 2, 1, 4, 5, 4, 3, 1))
+
+    r <- jmv::ttestOneS(
+        df, testValue=3, vars="x", hypothesis="gt", wilcoxon=TRUE, students=FALSE, effectSize=TRUE
+    )
+
+    # Test rank biserial correlation
+    ttestTable <- r$ttest$asDF
+    testthat::expect_equal(-0.0303, ttestTable[['es[wilc]']], tolerance = 1e-4)
+})


### PR DESCRIPTION
Because the rank biserial effect size calculated ties based on a value of 0 instead of the actual testValue (which defaults to 0), the calculation did not take into account non-zero testValues. This commit fixes this by comparing calculated ties based on the testValue instead of a fixed value of 0.

Fixes jamovi/jamovi#1331