### PR TITLE
Install jmvcore from github instead of CRAN for gh actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,11 @@ jobs:
           extra-packages: any::rcmdcheck, any::XML, any::roxygen2
           needs: check
 
+      - name: Install jmvcore from GitHub
+        run: |
+          Rscript -e "install.packages('remotes')"
+          Rscript -e "remotes::install_github('jamovi/jmvcore')"
+
       - name: Document
         run: roxygen2::roxygenise(roclets = "rd")
         shell: Rscript {0}


### PR DESCRIPTION
This makes sure, the pipeline always uses the latest version of jmvcore instead of the CRAN version, which can be out of date.