### PR TITLE
logRegBin: add warning when coefficients are missing

### DIFF
--- a/R/logregbin.b.R
+++ b/R/logregbin.b.R
@@ -866,6 +866,14 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
                     index <- which(length(term) == sapply(rowTerms, length) &
                                        sapply(rowTerms, function(x) all(term %in% x)))
 
+                    if (length(index) != 1) {
+                        table$setNote(
+                            "singular",
+                            .("Not all coefficients could be estimated (likely due to singular fit)")
+                        )
+                        next
+                    }
+
                     row <- list()
                     row[["est"]] <- coef[index, 'Estimate']
                     row[["se"]] <- coef[index, 'Std. Error']

--- a/tests/testthat/testlogregbin.R
+++ b/tests/testthat/testlogregbin.R
@@ -362,3 +362,30 @@ testthat::test_that("Analysis works with global weights", {
 })
 
 
+testthat::test_that("Analysis adds note when design matrix is singular", {
+    # GIVEN a singular data set
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+    df <- data.frame(
+        dep = rep(0:1, times=50),
+        var1 = c(sample(letters[2:3], replace=TRUE, 50), rep(letters[1], 50)),
+        var2 = c(sample(LETTERS[2:3], replace=TRUE, 50), rep(LETTERS[1], 50))
+    )
+    refLevels = list(
+        list(var="dep", ref="0"), list(var="var1", ref=letters[1]), list(var="var2", ref=LETTERS[1])
+    )
+
+    # WHEN a binomial logistic regression is run on this data set
+    r <- jmv::logRegBin(
+        df,
+        dep="dep",
+        factors=c("var1", "var2"),
+        blocks=list(list("var1", "var2")),
+        refLevels=refLevels
+    )
+
+    # THEN the coefficients table contains a note informing the user on the singularity of the data
+    notes <- r$models[[1]]$coef$notes
+    testthat::expect_true("singular" %in% names(notes))
+})
+


### PR DESCRIPTION
Previously, when a model couldn't estimate all the coefficients (most likely due to singularity issues) the analysis would fail. This commit, allows the analysis to still be run, but adds a warning message underneath the table.

closes https://github.com/jamovi/jamovi/issues/1349