### PR TITLE
Bugfix/fix t tests r 4 4

### DIFF
--- a/R/ttestis.b.R
+++ b/R/ttestis.b.R
@@ -126,7 +126,7 @@ ttestISClass <- R6::R6Class(
                     else if (any(is.infinite(dataTTest$dep)))
                         res <- createError(.('Variable contains infinite values'))
                     else
-                        res <- try(t.test(dep ~ group, data=dataTTest, var.equal=TRUE, paired=FALSE,
+                        res <- try(t.test(dep ~ group, data=dataTTest, var.equal=TRUE,
                                           alternative=Ha, conf.level=confInt), silent=TRUE)
 
                     if (isError(res)) {
@@ -181,7 +181,7 @@ ttestISClass <- R6::R6Class(
                     else if (any(is.infinite(dataTTest$dep)))
                         res <- createError(.('Variable contains infinite values'))
                     else
-                        res <- try(t.test(dep ~ group, data=dataTTest, var.equal=FALSE, paired=FALSE,
+                        res <- try(t.test(dep ~ group, data=dataTTest, var.equal=FALSE,
                                           alternative=Ha, conf.level=confInt), silent=TRUE)
 
                     if ( ! isError(res)) {


### PR DESCRIPTION
Since R 4.4.0 the t.test call doesn't allow for the "paired"
parameter to be set anymore when using a formula to define the
model. Removing the parameter fixes the bug

Fixes #401