### PR TITLE
tTestIS: Allow rank biserial correlation to be negative

### DIFF
--- a/R/ttestis.b.R
+++ b/R/ttestis.b.R
@@ -281,8 +281,7 @@ ttestISClass <- R6::R6Class(
                         if ( ! is.na(m1) && m2 < m1)
                             res <- res2
 
-                        biSerial <- 1 - (2 * res$statistic / (n[1] * n[2]))
-
+                        biSerial <- 1 - (2 * m1 / (n[1] * n[2]))
                     }
 
                     if ( ! isError(res)) {

--- a/tests/testthat/testttestis.R
+++ b/tests/testthat/testttestis.R
@@ -54,7 +54,7 @@ testthat::test_that('All options in the ttestIS work (sunny)', {
     testthat::expect_equal(c(-0.328, 0.019), ttestTable[['md[mann]']], tolerance = 1e-3)
     testthat::expect_equal(c(-0.738, -0.37), ttestTable[['cil[mann]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.115, 0.422), ttestTable[['ciu[mann]']], tolerance = 1e-3)
-    testthat::expect_equal(c(0.174, 0.013), ttestTable[['es[mann]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.174, -0.013), ttestTable[['es[mann]']], tolerance = 1e-3)
 
     # Test normality tests table
     normTable <- r$assum$norm$asDF
@@ -128,5 +128,21 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     ttestTable <- r$ttest$asDF
     testthat::expect_equal(2, ttestTable[['stat[mann]']])
     testthat::expect_equal(0.063, ttestTable[['p[mann]']], tolerance = 1e-3)
-    testthat::expect_equal(0.8, ttestTable[['es[mann]']])
+    testthat::expect_equal(-0.8, ttestTable[['es[mann]']])
+})
+
+testthat::test_that('Rank biserial correlation can be negative', {
+    df <- data.frame(
+        score = c(3, 4, 7, 8, 5, 9),
+        group = c('spr', 'spr', 'spr', 'ctrl', 'ctrl', 'ctrl'),
+        stringsAsFactors = TRUE
+    )
+
+    r <- jmv::ttestIS(df, vars="score", group="group", mann=TRUE, students=FALSE, effectSize=TRUE)
+
+    # Test rank biserial correlation
+    ttestTable <- r$ttest$asDF
+    testthat::expect_equal(1, ttestTable[['stat[mann]']])
+    testthat::expect_equal(0.2, ttestTable[['p[mann]']])
+    testthat::expect_equal(-0.778, ttestTable[['es[mann]']], tolerance = 1e-3)
 })


### PR DESCRIPTION
Rank biserial correlation previously used the given test-statistic (the Mann-Whitney U) to calculate the rank biserial correlation. However, because the Mann-Whitney U always takes the smallest of the two calculated Us this means that the rank biserial correlation is always positive and therefore doesn't indicate directionality of the effect. This commit fixes this.

Fixes https://github.com/jamovi/jamovi/issues/1500