### PR TITLE
cfa: Fix exception handling bug

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -89,7 +89,7 @@ cfaErrors = list(
         class = exceptions$modelError
     ),
     list(
-        originalMessage = 'lavaan ERROR: fit measures not available if model did not converge',
+        originalMessage = 'fit measures not available if model did not converge',
         message = "Model dit not converge",
         class = exceptions$modelError
     )


### PR DESCRIPTION
An update in lavaan has caused a lot of their error messages to change. Because we catch a couple of exceptions based on these messages, some of the error were not caught anymore. This also cause one unit test to fail, flagging `jmv` for removal by CRAN. To fix this, the message that we use to catch the error, was changed so that it's compatible with both old and new versions of lavaan.