### PR TITLE
Git ignore all renv related stuff

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 
 ^\..*
 ^.*\.Rproj$

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ build*/
 # i18n
 inst/i18n
 
+# renv related stuff
+.Rprofile
+renv/
+renv.lock
+
 # other files / folders
 temp/
 man/


### PR DESCRIPTION
This makes it easy to use a isolated environment for jmv development without it being committed and potentially used in the actions or build pipeline.