### PR TITLE
Improve reference level handling

### DIFF
--- a/R/linreg.b.R
+++ b/R/linreg.b.R
@@ -120,14 +120,8 @@ linRegClass <- R6::R6Class(
                 )
                 private$.refLevels <- refLevels$refLevels
 
-                if (length(refLevels$changedVars) > 0) {
-                    private$.setWarningMessage(
-                        jmvcore::format(
-                            .("The specified reference level was not found for the following variable(s): {vars}. Defaulting to the first available level. To use a custom reference level, ensure the defined reference level is available in the data."),
-                            vars=listItems(self, refLevels$changedVars)
-                        )
-                    )
-                }
+                if (length(refLevels$changedVars) > 0)
+                    setRefLevelWarning(self, refLevels$changedVars)
             }
 
             return(private$.refLevels)
@@ -1272,15 +1266,6 @@ linRegClass <- R6::R6Class(
             }
 
             return(private$.isAliased)
-        },
-        .setWarningMessage = function(message) {
-            notice <- jmvcore::Notice$new(
-                options = self$options,
-                name = 'warningMessage',
-                type = jmvcore::NoticeType$STRONG_WARNING
-            )
-            notice$setContent(message)
-            self$results$insert(1, notice)
         },
         .contrastModel = function(terms) {
             #' Returns the names of the factor contrasts as they are

--- a/R/linreg.b.R
+++ b/R/linreg.b.R
@@ -112,6 +112,12 @@ linRegClass <- R6::R6Class(
                 private$.emMeans <- private$.computeEmMeans()
 
             return(private$.emMeans)
+        },
+        refLevels = function() {
+            if (is.null(private$.refLevels))
+                private$.refLevels <- private$.getRefLevels()
+
+            return(private$.refLevels)
         }
     ),
     private = list(
@@ -139,6 +145,7 @@ linRegClass <- R6::R6Class(
         .rowNamesModel = NULL,
         .emMeans = NULL,
         .emMeansForPlot = NULL,
+        .refLevels = NULL,
 
         #### Init + run functions ----
         .init = function() {
@@ -1206,6 +1213,33 @@ linRegClass <- R6::R6Class(
 
             return(private$.modelTerms)
         },
+        .getRefLevels = function() {
+            factors <- self$options$factors
+            refLevels <- self$options$refLevels
+
+            updatedRefLevels <- list()
+
+            # Create a named list from the refLevels input for easier access
+            refLevelsList <- setNames(
+                lapply(refLevels, function(ref) ref$ref),
+                sapply(refLevels, function(ref) ref$var)
+            )
+
+            for (varName in factors) {
+                factorLevels <- levels(self$data[[varName]])
+                refLevel <- refLevelsList[[varName]]
+
+                # If no refLevel is provided or the provided level is invalid, use the first level
+                if (is.null(refLevel) || ! (refLevel %in% factorLevels))
+                    refLevel <- factorLevels[1]
+
+                updatedRefLevels[[length(updatedRefLevels) + 1]] <- list(
+                    var = varName, ref = refLevel
+                )
+            }
+
+            return(updatedRefLevels)
+        },
         .getRowNamesModel = function() {
             if (is.null(private$.rowNamesModel)) {
                 factors <- self$options$factors
@@ -1284,7 +1318,7 @@ linRegClass <- R6::R6Class(
             #' displayed in the coef table
 
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
             refVars <- sapply(refLevels, function(x) x$var)
 
             levels <- list()
@@ -1333,7 +1367,7 @@ linRegClass <- R6::R6Class(
             covs <- self$options$covs
             factors <- self$options$factors
             weights <- self$options$weights
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             dataRaw <- self$data
 

--- a/R/loglinear.b.R
+++ b/R/loglinear.b.R
@@ -3,8 +3,25 @@
 logLinearClass <- R6::R6Class(
     "logLinearClass",
     inherit = logLinearBase,
+    #### Active bindings ----
+    active = list(
+        refLevels = function() {
+            if (is.null(private$.refLevels)) {
+                refLevels <- getReferenceLevels(
+                    self$data, self$options$factors, self$options$refLevels
+                )
+                private$.refLevels <- refLevels$refLevels
+
+                if (length(refLevels$changedVars) > 0)
+                    setRefLevelWarning(self, refLevels$changedVars)
+            }
+
+            return(private$.refLevels)
+        }
+    ),
     private = list(
         #### Member variables ----
+        .refLevels = NULL,
         terms = NULL,
         coefTerms = list(),
         emMeans = list(),
@@ -553,7 +570,7 @@ logLinearClass <- R6::R6Class(
         .coefTerms = function(terms) {
 
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             refVars <- sapply(refLevels, function(x) x$var)
 
@@ -622,7 +639,7 @@ logLinearClass <- R6::R6Class(
         .cleanData = function() {
             counts <- self$options$counts
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             dataRaw <- self$data
 

--- a/R/logregbin.b.R
+++ b/R/logregbin.b.R
@@ -136,6 +136,20 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
                 private$.emMeans <- private$.computeEmMeans()
 
             return(private$.emMeans)
+        },
+        refLevels = function() {
+            if (is.null(private$.refLevels)) {
+                factors <- c(self$options$dep, self$options$factors)
+                refLevels <- getReferenceLevels(
+                    self$data, factors, self$options$refLevels
+                )
+                private$.refLevels <- refLevels$refLevels
+
+                if (length(refLevels$changedVars) > 0)
+                    setRefLevelWarning(self, refLevels$changedVars)
+            }
+
+            return(private$.refLevels)
         }
     ),
     private = list(
@@ -167,6 +181,7 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         .levelsDep = NULL,
         .emMeans = NULL,
         .emMeansForPlot = NULL,
+        .refLevels = NULL,
 
         #### Init + run functions ----
         .init = function() {
@@ -653,7 +668,7 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             groups <- self$results$models
             dep <- self$options$dep
             cutOff <- self$options$cutOff
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             data <- self$data
 
@@ -1295,7 +1310,7 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         },
         .getLevels = function(var) {
             levels <- levels(self$data[[var]])
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
             refVars <- sapply(refLevels, function(x) x$var)
             ref <- refLevels[[which(var == refVars)]][['ref']]
             # workaround ... client currently initially sends null
@@ -1350,7 +1365,7 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             dep <- self$options$dep
             covs <- self$options$covs
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             dataRaw <- self$data
 
@@ -1423,7 +1438,7 @@ logRegBinClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             #' displayed in the jmv coef table
 
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
             refVars <- sapply(refLevels, function(x) x$var)
 
             levels <- list()

--- a/R/logregmulti.b.R
+++ b/R/logregmulti.b.R
@@ -98,6 +98,20 @@ logRegMultiClass <- R6::R6Class(
                 private$.CICoefEstOR <- private$.computeCICoefEst(type="OR")
 
             return(private$.CICoefEstOR)
+        },
+        refLevels = function() {
+            if (is.null(private$.refLevels)) {
+                factors <- c(self$options$dep, self$options$factors)
+                refLevels <- getReferenceLevels(
+                    self$data, factors, self$options$refLevels
+                )
+                private$.refLevels <- refLevels$refLevels
+
+                if (length(refLevels$changedVars) > 0)
+                    setRefLevelWarning(self, refLevels$changedVars)
+            }
+
+            return(private$.refLevels)
         }
     ),
     private = list(
@@ -117,6 +131,7 @@ logRegMultiClass <- R6::R6Class(
         .modelTest = NULL,
         .CICoefEst = NULL,
         .CICoefEstOR = NULL,
+        .refLevels = NULL,
         terms = NULL,
         coefTerms = list(),
         emMeans = list(),
@@ -335,7 +350,7 @@ logRegMultiClass <- R6::R6Class(
             dep <- self$options$dep
 
             if ( ! is.null(dep) ) {
-                refLevels <- self$options$refLevels
+                refLevels <- self$refLevels
                 refVars <- sapply(refLevels, function(x) x$var)
                 depLevels <- levels(self$data[[dep]])
                 depRefLevel <- refLevels[[which(dep == refVars)]][['ref']]
@@ -728,7 +743,7 @@ logRegMultiClass <- R6::R6Class(
             factors <- self$options$factors
             dep <- self$options$dep
 
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             groups <- self$results$models
             termsAll <- private$terms
@@ -923,7 +938,7 @@ logRegMultiClass <- R6::R6Class(
         .coefTerms = function(terms) {
             covs <- self$options$covs
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             refVars <- sapply(refLevels, function(x) x$var)
 
@@ -1009,7 +1024,7 @@ logRegMultiClass <- R6::R6Class(
             dep <- self$options$dep
             covs <- self$options$covs
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             dataRaw <- self$data
 

--- a/R/logregord.b.R
+++ b/R/logregord.b.R
@@ -98,6 +98,19 @@ logRegOrdClass <- if (requireNamespace('jmvcore')) R6::R6Class(
                 private$.CICoefEstOR <- private$.computeCICoefEst(type="OR")
 
             return(private$.CICoefEstOR)
+        },
+        refLevels = function() {
+            if (is.null(private$.refLevels)) {
+                refLevels <- getReferenceLevels(
+                    self$data, self$options$factors, self$options$refLevels
+                )
+                private$.refLevels <- refLevels$refLevels
+
+                if (length(refLevels$changedVars) > 0)
+                    setRefLevelWarning(self, refLevels$changedVars)
+            }
+
+            return(private$.refLevels)
         }
     ),
     private = list(
@@ -117,6 +130,7 @@ logRegOrdClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         .modelTest = NULL,
         .CICoefEst = NULL,
         .CICoefEstOR = NULL,
+        .refLevels = NULL,
         terms = NULL,
         coefTerms = list(),
         thresTerms = list(),
@@ -605,7 +619,7 @@ logRegOrdClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         .coefTerms = function(terms) {
             covs <- self$options$covs
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             refVars <- sapply(refLevels, function(x) x$var)
 
@@ -689,7 +703,7 @@ logRegOrdClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             dep <- self$options$dep
             covs <- self$options$covs
             factors <- self$options$factors
-            refLevels <- self$options$refLevels
+            refLevels <- self$refLevels
 
             dataRaw <- self$data
 

--- a/R/regutils.R
+++ b/R/regutils.R
@@ -1,0 +1,35 @@
+#' Update reference levels for a set of variables
+#'
+#' @param data The data frame containing the variables
+#' @param vars The names of the variables to update
+#' @param refLevels A list of reference levels to use for each variable
+#' @return A list of updated reference levels and a list of variables that
+#'   had their reference levels changed
+#' @keywords internal
+getReferenceLevels = function(data, vars, refLevels) {
+    updatedRefLevels <- list()
+    changedVars <- c()
+
+    # Create a named list from the refLevels input for easier access
+    refLevelsList <- setNames(
+        lapply(refLevels, function(ref) ref$ref),
+        sapply(refLevels, function(ref) ref$var)
+    )
+
+    for (var in vars) {
+        factorLevels <- levels(data[[var]])
+        refLevel <- refLevelsList[[var]]
+
+        # If no refLevel is provided or the provided level is invalid, use the first level
+        if (is.null(refLevel) || ! (refLevel %in% factorLevels)) {
+            refLevel <- factorLevels[1]
+            changedVars <- c(changedVars, var)
+        }
+
+        updatedRefLevels[[ length(updatedRefLevels) + 1 ]] <- list(
+            var = var, ref = refLevel
+        )
+    }
+
+    return(list(refLevels=updatedRefLevels, changedVars=changedVars))
+}

--- a/R/regutils.R
+++ b/R/regutils.R
@@ -11,7 +11,7 @@ getReferenceLevels = function(data, vars, refLevels) {
     changedVars <- c()
 
     # Create a named list from the refLevels input for easier access
-    refLevelsList <- setNames(
+    refLevelsList <- stats::setNames(
         lapply(refLevels, function(ref) ref$ref),
         sapply(refLevels, function(ref) ref$var)
     )
@@ -32,4 +32,21 @@ getReferenceLevels = function(data, vars, refLevels) {
     }
 
     return(list(refLevels=updatedRefLevels, changedVars=changedVars))
+}
+
+
+#' Set a warning notice for reference level changes
+#'
+#' @param self The analysis object
+#' @param changedVars The variables that had their reference levels changed
+#' @keywords internal
+setRefLevelWarning = function(self, changedVars) {
+    message <- jmvcore::format(
+        .("The specified reference level was not found for the following variable(s): {vars}. Defaulting to the first available level. To use a custom reference level, ensure the defined reference level is available in the data."),
+        vars=listItems(self, changedVars)
+    )
+
+    setAnalysisNotice(
+        self, message, name="refLevelWarning", type=jmvcore::NoticeType$STRONG_WARNING
+    )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,3 +152,20 @@ listItems <- function(self, items, quote = '\'') {
 
     return(l)
 }
+
+#' Set a global analysis notice
+#'
+#' @param self The analysis object
+#' @param message The message to set
+#' @param name The name of the notice
+#' @param type The type of the notice
+#' @keywords internal
+setAnalysisNotice = function(self, message, name, type) {
+    notice <- jmvcore::Notice$new(
+        options = self$options,
+        name = 'warningMessage',
+        type = jmvcore::NoticeType$STRONG_WARNING
+    )
+    notice$setContent(message)
+    self$results$insert(1, notice)
+}

--- a/tests/testthat/testlinreg.R
+++ b/tests/testthat/testlinreg.R
@@ -694,5 +694,6 @@ testthat::test_that('Reference level defaults to first level for faulty referenc
         testthat::expect_match(r$models[[1]]$coef$asDF$term[3], "B – A", info=param$info)
         # AND a warning is added informing the user that the user defined reference level does not
         #   exist and therefore was changed to the first level
+        testthat::expect_match(r[[1]]$content, "reference level was not found")
     }
 })

--- a/tests/testthat/testlinreg.R
+++ b/tests/testthat/testlinreg.R
@@ -694,6 +694,6 @@ testthat::test_that('Reference level defaults to first level for faulty referenc
         testthat::expect_match(r$models[[1]]$coef$asDF$term[3], "B – A", info=param$info)
         # AND a warning is added informing the user that the user defined reference level does not
         #   exist and therefore was changed to the first level
-        testthat::expect_match(r[[1]]$content, "reference level was not found")
+        testthat::expect_match(r[[1]]$content, "reference level was not found", info=param$info)
     }
 })

--- a/tests/testthat/testlogregmulti.R
+++ b/tests/testthat/testlogregmulti.R
@@ -272,4 +272,37 @@ testthat::test_that('Model fit table contains sample size footnote', {
     testthat::expect_match(r$modelFit$notes$n$note, "N=16")
 })
 
+params <- list(
+    list(refLevels = list(list(var="dep", ref="x"), list(var="factor", ref="X")), info = "Non-existing reference levels"),
+    list(refLevels = NULL, info = "No reference levels"),
+    list(refLevels = list(list(var="wrong_factor", ref="A")), info = "Wrong variable name")
+)
+testthat::test_that('Reference level defaults to first level for faulty reference levels', {
+    for (param in params) {
+        # GIVEN a dataset with a factor with two levels
+        df <- data.frame(
+            dep = rep(letters[1:3], length.out=10),
+            factor = rep(LETTERS[1:2], length.out=10),
+            stringsAsFactors = TRUE
+        )
+
+        # WHEN a multinomial logistic regression is fitted with reference level set to a non-existing level
+        r <- jmv::logRegMulti(
+            df,
+            dep = "dep",
+            factors = "factor",
+            blocks = list(list("factor")),
+            refLevels = param$refLevels
+        )
+
+        # THEN the reference level should default to the first level for the dep variable
+        testthat::expect_match(r$models[[1]]$coef$asDF$dep[1], "b - a", info=param$info)
+        # THEN the reference level should default to the first level for the factor
+        testthat::expect_match(r$models[[1]]$coef$asDF$term[3], "B – A", info=param$info)
+        # AND a warning is added informing the user that the user defined reference level does not
+        #   exist and therefore was changed to the first level
+        testthat::expect_match(r[[1]]$content, "reference level was not found", info=param$info)
+    }
+})
+
 

--- a/tests/testthat/testregutils.R
+++ b/tests/testthat/testregutils.R
@@ -1,0 +1,77 @@
+testthat::context('regutils')
+
+testthat::test_that("Correct reference levels are not updated", {
+    # GIVEN a dataframe with a factor column
+    df <- data.frame(
+        var = c('a', 'b', 'c', 'd', 'e'),
+        stringsAsFactors = TRUE
+    )
+    # AND correctly defined reference levels
+    refLevels <- list(list(var="var", ref="a"))
+
+    # WHEN the reference levels are updated
+    refLevelsUpdated <- jmv:::getReferenceLevels(df, "var", refLevels)
+
+    # THEN the updated reference levels are the same as the original
+    testthat::expect_equal(refLevelsUpdated$refLevels, refLevels)
+    # AND the reference levels are not updated
+    testthat::expect_false(length(refLevelsUpdated$changedVars) > 0)
+})
+
+testthat::test_that("Reference levels are set correctly with no original reference levels", {
+    # GIVEN a dataframe with a factor column
+    df <- data.frame(
+        var = c('a', 'b', 'c', 'd', 'e'),
+        stringsAsFactors = TRUE
+    )
+    # AND no original reference levels
+    refLevels <- list()
+
+    # WHEN the reference levels are updated
+    refLevelsUpdated <- jmv:::getReferenceLevels(df, "var", refLevels)
+
+    # THEN the updated reference levels are set to the first level
+    testthat::expect_equal(refLevelsUpdated$refLevels, list(list(var="var", ref="a")))
+    # AND the reference levels are updated
+    testthat::expect_true(length(refLevelsUpdated$changedVars) > 0)
+})
+
+testthat::test_that("Reference levels are corrected with faulty orginal reference levels", {
+    # GIVEN a dataframe with a factor column
+    df <- data.frame(
+        var = c('a', 'b', 'c', 'd', 'e'),
+        stringsAsFactors = TRUE
+    )
+    # AND faulty original reference levels
+    refLevels <- list(list(var="var", ref="X"))
+
+    # WHEN the reference levels are updated
+    refLevelsUpdated <- jmv:::getReferenceLevels(df, "var", refLevels)
+
+    # THEN the updated reference levels are set to the first level
+    testthat::expect_equal(refLevelsUpdated$refLevels, list(list(var="var", ref="a")))
+    # AND the reference levels are updated
+    testthat::expect_true(length(refLevelsUpdated$changedVars) > 0)
+})
+
+testthat::test_that("Reference levels are added when level is not contained in original", {
+    # GIVEN a dataframe with two factors
+    df <- data.frame(
+        var1 = rep(letters[1:2], length.out=10),
+        var2 = rep(LETTERS[3:4], length.out=10),
+        stringsAsFactors = TRUE
+    )
+    # AND the original reference levels are only set for var1
+    refLevels <- list(list(var="var1", ref="a"))
+
+    # WHEN the reference levels are updated
+    refLevelsUpdated <- jmv:::getReferenceLevels(df, c("var1", "var2"), refLevels)
+
+    # THEN the updated reference levels are set to the first level
+    testthat::expect_equal(
+        refLevelsUpdated$refLevels,
+        list(list(var="var1", ref="a"), list(var="var2", ref="C"))
+    )
+    # AND the reference levels are updated
+    testthat::expect_true(length(refLevelsUpdated$changedVars) > 0)
+})


### PR DESCRIPTION
To improve the reference level handling in the analyses that make use of them, I defaulted the reference level to the first level of a factor if no or wrong reference level is defined.

The analyses that make use of the reference level updater are:
 - linReg
 - logRegBin
 - logRegMulti
 - logRegOrd
 - logLinear