### PR TITLE
Added post-hoc table for residuals

### DIFF
--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -245,9 +245,8 @@ contTablesClass <- R6::R6Class(
             gamma$getColumn('cil')$setSuperTitle(ciText)
             gamma$getColumn('ciu')$setSuperTitle(ciText)
 
+            private$.initPostHocTable(data=data)
             private$.initBarPlot()
-
-            private$.initPhocTab(data=data)
         },
         .run=function() {
 
@@ -592,125 +591,149 @@ contTablesClass <- R6::R6Class(
 
                 othRowNo <- othRowNo + 1
             }
-            private$.runPhocTab(data=data)
+            private$.populatePostHocTable(data=data)
         },
-        .initPhocTab=function(data=data) {
+
+        #### PostHoc Table functions
+        .initPostHocTable = function(data=data) {
             rowVarName <- self$options$rows
             colVarName <- self$options$cols
             layerNames <- self$options$layers
-            phoc       <- self$results$phoc
+            postHoc    <- self$results$postHoc
 
-            subNamesPh  <- c('[resU]', '[resP]', '[resS]', '[resA]')
-            subTitlesPh <- c(.('Unstandardized'), .('Pearson'), .('Standardized'), .('Adjusted'))
-            visiblePh   <- c('(resU)', '(resP)', '(resS)', '(resA)')
-            typesPh     <- c('number', 'number', 'number', 'number')
-            formatsPh   <- c('', '', '', '')
+            subNamesPh    <- c('[resU]', '[resP]', '[resS]', '[resA]')
+            subTitlesPh   <- c(.('Unstandardized'), .('Pearson'), .('Standardized'), .('Adjusted'))
+            visiblePh     <- c('(resU)', '(resP)', '(resS)', '(resA)')
+            typesPh       <- c('number', 'number', 'number', 'number')
+            formatsPh     <- c('', '', '', '')
 
+            # Add layer columns on top (if any)
             reversed <- rev(layerNames)
-            for (i in seq_along(reversed)) {
-                layer <- reversed[[i]]
-                phoc$addColumn(name=layer, type='text', combineBelow=TRUE)
+            for (layer in reversed) {
+                postHoc$addColumn(name=layer, type='text', combineBelow=TRUE)
             }
 
-            # add the row column, containing the row variable
-            # fill in dots, if no row variable specified
+            # Add the row variable column or a placeholder if absent
+            rowTitle <- if (!is.null(rowVarName)) rowVarName else '.'
+            postHoc$addColumn(name=rowTitle, title=rowTitle, type='text')
 
-            if ( ! is.null(rowVarName))
-                title <- rowVarName
-            else
-                title <- '.'
-
-            phoc$addColumn(
-                name=title,
-                title=title,
-                type='text')
-
-            # add the column columns (from the column variable)
-            # fill in dots, if no column variable specified
-
-            if ( ! is.null(colVarName)) {
+            # Determine the column variable levels or use placeholders
+            if (!is.null(colVarName)) {
                 superTitle <- colVarName
-                levels <- base::levels(data[[colVarName]])
-            }
-            else {
+                levels     <- levels(data[[colVarName]])
+            } else {
                 superTitle <- '.'
-                levels <- c('.', '.')
+                levels     <- c('.', '.')
             }
 
-            # iterate over the sub rows
+            # Determine how many residuals are selected
+            residualSelections <- c(
+                isTRUE(self$options$resU),
+                isTRUE(self$options$resP),
+                isTRUE(self$options$resS),
+                isTRUE(self$options$resA)
+            )
+            numResSelected <- sum(residualSelections)
+
+            # Improve clarity with descriptive variables
+            oneResidualSelected <- (numResSelected == 1)
+            multipleResidualsSelected <- (numResSelected > 1)
+
+            # Set the table title and determine if the Residuals column should be shown
+            if (oneResidualSelected) {
+                selectedIndex   <- which(residualSelections)
+                singleResTitle  <- subTitlesPh[selectedIndex]
+                postHoc$setTitle(jmvcore::format("Post Hoc Test ({title} Residuals)", title=singleResTitle))
+                showResidualsCol <- FALSE
+            } else {
+                postHoc$setTitle(.('Post Hoc Test'))
+                showResidualsCol <- multipleResidualsSelected
+            }
+
+            # Add the "Residuals" columns
             for (j in seq_along(subNamesPh)) {
-                subName <- subNamesPh[[j]]
-                if (subName == '[resU]')
-                    vPh <- '(resU && (resP || resS || resA))'
-                else
-                    vPh <- visiblePh[j]
+                subName <- subNamesPh[j]
 
-                # Post-hoc residuals table
-                phoc$addColumn(
-                    name=paste0('type', subName),
-                    title='Residuals',
-                    type='text',
-                    visible=vPh)
+                # Determine visibility for this residual type column
+                if (showResidualsCol) {
+                    if (subName == '[resU]') {
+                        # Visible only if resU and at least one other residual is present
+                        vPh <- '(resU && (resP || resS || resA))'
+                    } else {
+                        vPh <- visiblePh[j]
+                    }
+                } else {
+                    # Only one residual selected: Residuals column hidden
+                    vPh <- 'FALSE'
+                }
+
+                postHoc$addColumn(
+                    name  = paste0('type', subName),
+                    title = 'Residuals',
+                    type  = 'text',
+                    visible = vPh
+                )
             }
 
+            # Add columns for the factor levels of the column variable
             for (i in seq_along(levels)) {
-                level <- levels[[i]]
-
+                level <- levels[i]
                 for (j in seq_along(subNamesPh)) {
-                    subName <- subNamesPh[[j]]
-                    phoc$addColumn(
-                        name=paste0(i, subName),
-                        title=level,
-                        superTitle=superTitle,
-                        type=typesPh[j],
-                        format=formatsPh[j],
-                        visible=visiblePh[j])
+                    subName <- subNamesPh[j]
+                    postHoc$addColumn(
+                        name       = paste0(i, subName),
+                        title      = level,
+                        superTitle = superTitle,
+                        type       = typesPh[j],
+                        format     = formatsPh[j],
+                        visible    = visiblePh[j]
+                    )
                 }
             }
 
-            # populate the first column with levels of the row variable
-
-            values <- list()
-            for (i in seq_along(subNamesPh))
-                values[[paste0('type', subNamesPh[i])]] <- subTitlesPh[i]
-
+            # Prepare row expansion (for row variable and layers)
             expand <- list()
             if (is.null(rowVarName))
                 expand[['.']] <- '.'
             else
-                expand[[rowVarName]] <- c(base::levels(data[[rowVarName]]))
+                expand[[rowVarName]] <- levels(data[[rowVarName]])
 
             for (layerName in layerNames)
-                expand[[layerName]] <- base::levels(data[[layerName]])
+                expand[[layerName]] <- levels(data[[layerName]])
 
             rows <- rev(expand.grid(expand))
 
+            # Prepare values for the "type[subName]" columns
+            values <- list()
+            for (i in seq_along(subNamesPh)) {
+                colName <- paste0('type', subNamesPh[i])
+                values[[colName]] <- subTitlesPh[i]
+            }
+
+            # Add rows to the table
             nextIsNewGroup <- TRUE
-
             for (i in seq_len(nrow(rows))) {
-
-                for (name in colnames(rows)) {
-                    value <- as.character(rows[i, name])
-                    values[[name]] <- value
+                for (colName in colnames(rows)) {
+                    values[[colName]] <- as.character(rows[i, colName])
                 }
 
-                key <- paste0(rows[i,], collapse='`')
-                phoc$addRow(rowKey=key, values=values)
+                key <- paste0(rows[i, ], collapse='`')
+                postHoc$addRow(rowKey=key, values=values)
 
                 if (nextIsNewGroup) {
-                    phoc$addFormat(rowNo=i, 1, Cell.BEGIN_GROUP)
+                    postHoc$addFormat(rowNo=i, 1, Cell.BEGIN_GROUP)
                     nextIsNewGroup <- FALSE
                 }
             }
         },
-        .runPhocTab=function(data=data) {
+        .populatePostHocTable = function(data=data) {
 
             rowVarName <- self$options$rows
             colVarName <- self$options$cols
             layerNames <- self$options$layers
-            phoc       <- self$results$phoc
+            postHoc    <- self$results$postHoc
 
-            matsPh <- list()
+            # Build the frequency tables (same logic as before)
             if (length(layerNames) == 0) {
                 matsPh <- list(ftable(xtabs(.COUNTS ~ ., data=data)))
             } else {
@@ -724,26 +747,21 @@ contTablesClass <- R6::R6Class(
 
                 expand <- list()
                 for (layerName in layerNames)
-                    expand[[layerName]] <- base::levels(data[[layerName]])
-
+                    expand[[layerName]] <- levels(data[[layerName]])
                 rows <- rev(expand.grid(expand))
 
                 expand <- list()
                 for (layerName in layerNames)
-                    expand[[layerName]] <- base::levels(data[[layerName]])
-
+                    expand[[layerName]] <- levels(data[[layerName]])
                 tableNames <- rev(expand.grid(expand))
 
                 matsPh <- list()
                 for (i in seq_along(rows[,1])) {
-
+                    rowLevels <- as.character(unlist(rows[i,]))
                     indices <- c()
                     for (j in seq_along(tableNames[,1])) {
-
-                        row <- as.character(unlist((rows[i,])))
-                        tableName <- as.character(unlist(tableNames[j,]))
-
-                        if (all(row == tableName | row == '.total'))
+                        tableNameLevels <- as.character(unlist(tableNames[j,]))
+                        if (all(rowLevels == tableNameLevels | rowLevels == '.total'))
                             indices <- c(indices, j)
                     }
                     matsPh[[i]] <- Reduce(`+`, tables[indices])
@@ -754,126 +772,104 @@ contTablesClass <- R6::R6Class(
             nCols <- base::nlevels(data[[colVarName]])
 
             freqRowNo <- 1
-            for (mat in matsPh) {
 
+            # Determine highlight thresholds
+            hlValueP <- if (self$options$resP || self$options$hlresP) jmvcore::toNumeric(self$options$hlresP) else NA
+            hlValueS <- if (self$options$resS || self$options$hlresS) jmvcore::toNumeric(self$options$hlresS) else NA
+            hlValueA <- if (self$options$resA || self$options$hlresA) jmvcore::toNumeric(self$options$hlresA) else NA
+
+            # Recalculate residuals every time (simple approach, as in CFA code)
+            for (mat in matsPh) {
                 suppressWarnings({
                     test <- try(chisq.test(mat, correct=FALSE))
+                    exp <- if (inherits(test, 'try-error')) mat else test$expected
+                })
 
-                    if (inherits(test, 'try-error')) {
-                        exp <- mat
-                    } else {
-                        exp <- test$expected
-                    }
-                }) # suppressWarnings
-
-                # Calculate residues, if required
+                residualsU <- residualsP <- residualsS <- residualsA <- NULL
                 if (self$options$resU || self$options$resP || self$options$resS || self$options$resA) {
+                    # Compute residuals straightforwardly
                     if (inherits(test, 'try-error')) {
                         residualsU <- matrix(NA, nrow=nrow(mat), ncol=ncol(mat))
                         residualsP <- matrix(NA, nrow=nrow(mat), ncol=ncol(mat))
                         residualsS <- matrix(NA, nrow=nrow(mat), ncol=ncol(mat))
                     } else {
-                        residualsU <- (mat - exp)
+                        residualsU <- mat - exp
                         residualsP <- test$residuals
                         residualsS <- test$stdres
                     }
-                    # Adjusted Residuals: Standardized residuals from a GLM
+
                     df <- as.data.frame(as.table(mat))
                     names(df) <- c("Row", "Col", "Count")
                     model <- try(glm(Count ~ Row + Col, data=df, family=poisson()), silent=TRUE)
                     if (!inherits(model, 'try-error')) {
                         resAvector <- residuals(model, type="deviance")
-                        residualsA <- matrix(resAvector,
-                                             nrow=nrow(mat),
-                                             ncol=ncol(mat),
-                                             byrow=FALSE,
-                                             dimnames=dimnames(mat))
+                        residualsA <- matrix(
+                            resAvector,
+                            nrow=nrow(mat),
+                            ncol=ncol(mat),
+                            byrow=FALSE,
+                            dimnames=dimnames(mat)
+                        )
                     } else {
                         residualsA <- matrix(NA, nrow=nrow(mat), ncol=ncol(mat))
                     }
                 }
 
+                # Internal helper
+                getValues <- function(active, residuals, suffix) {
+                    if (!active || is.null(residuals))
+                        return(list())
+                    vals <- as.list(residuals[rowNo, ])
+                    names(vals) <- paste0(seq_len(nCols), suffix)
+                    vals
+                }
+
+                # Now populate rows and highlight
                 for (rowNo in seq_len(nRows)) {
 
-                    if (self$options$resU) {
-                        resUValues <- residualsU[rowNo, ]
-                        resUValues <- as.list(resUValues)
-                        names(resUValues) <- paste0(1:nCols, '[resU]')
-                    } else {
-                        resUValues <- list()
-                    }
+                    rowValues <- c(
+                        getValues(self$options$resU, residualsU, "[resU]"),
+                        getValues(self$options$resP, residualsP, "[resP]"),
+                        getValues(self$options$resS, residualsS, "[resS]"),
+                        getValues(self$options$resA, residualsA, "[resA]")
+                    )
 
-                    if (self$options$resP) {
-                        resPValues <- residualsP[rowNo, ]
-                        resPValues <- as.list(resPValues)
-                        names(resPValues) <- paste0(1:nCols, '[resP]')
-                    } else {
-                        resPValues <- list()
-                    }
+                    # Set values for this row
+                    postHoc$setRow(rowNo=freqRowNo, values=rowValues)
 
-                    if (self$options$resS) {
-                        resSValues <- residualsS[rowNo, ]
-                        resSValues <- as.list(resSValues)
-                        names(resSValues) <- paste0(1:nCols, '[resS]')
-                    } else {
-                        resSValues <- list()
-                    }
+                    # Apply highlighting just like in the CFA code:
+                    # Check each cell and if it exceeds the threshold, add format
+                    for (colIndex in seq_len(nCols)) {
 
-                    if (self$options$resA) {
-                        resAValues <- residualsA[rowNo, ]
-                        resAValues <- as.list(resAValues)
-                        names(resAValues) <- paste0(1:nCols, '[resA]')
-                    } else {
-                        resAValues <- list()
-                    }
+                        # Pearson
+                        if (!is.na(hlValueP) && self$options$resP) {
+                            resValueP <- residualsP[rowNo, colIndex]
+                            if (!is.na(resValueP) && abs(resValueP) > hlValueP)
+                                postHoc$addFormat(rowNo=freqRowNo, col=paste0(colIndex, "[resP]"), Cell.NEGATIVE)
+                        }
 
-                    values <- c(resUValues, resPValues, resSValues, resAValues)
+                        # Standardized
+                        if (!is.na(hlValueS) && self$options$resS) {
+                            resValueS <- residualsS[rowNo, colIndex]
+                            if (!is.na(resValueS) && abs(resValueS) > hlValueS) {
+                                postHoc$addFormat(rowNo=freqRowNo, col=paste0(colIndex, "[resS]"), Cell.NEGATIVE)
+                            }
+                        }
 
-                    phoc$setRow(rowNo=freqRowNo, values=values)
-
-                    # Formatting for significant residues
-                    if (self$options$resP) {
-                        for (colIndex in seq_len(nCols)) {
-                            colName <- paste0(colIndex, '[resP]')
-                            resValue <- residualsP[rowNo, colIndex]
-                            if (!is.na(resValue) && abs(resValue) > 2) {
-                                phoc$addFormat(rowNo=freqRowNo, col=colName, Cell.NEGATIVE)
-                                phoc$addFootnote(rowNo=freqRowNo,
-                                                 col=colName,
-                                                 .('Pearson Residuals: (Observed - Expected) / sqrt(Expected).'))
+                        # Adjusted
+                        if (!is.na(hlValueA) && self$options$resA) {
+                            resValueA <- residualsA[rowNo, colIndex]
+                            if (!is.na(resValueA) && abs(resValueA) > hlValueA) {
+                                postHoc$addFormat(rowNo=freqRowNo, col=paste0(colIndex, "[resA]"), Cell.NEGATIVE)
                             }
                         }
                     }
 
-                    if (self$options$resS) {
-                        for (colIndex in seq_len(nCols)) {
-                            colName <- paste0(colIndex, '[resS]')
-                            resValue <- residualsS[rowNo, colIndex]
-                            if (!is.na(resValue) && abs(resValue) > 2) {
-                                phoc$addFormat(rowNo=freqRowNo, col=colName, Cell.NEGATIVE)
-                                phoc$addFootnote(rowNo=freqRowNo,
-                                                 col=colName,
-                                                 .('Standardized Residuals: (Adjusted Pearson) scaled for row and column proportions.'))
-                            }
-                        }
-                    }
-
-                    if (self$options$resA) {
-                        for (colIndex in seq_len(nCols)) {
-                            colName <- paste0(colIndex, '[resA]')
-                            resValue <- residualsA[rowNo, colIndex]
-                            if (!is.na(resValue) && abs(resValue) > 2) {
-                                phoc$addFormat(rowNo=freqRowNo, col=colName, Cell.NEGATIVE)
-                                phoc$addFootnote(rowNo=freqRowNo,
-                                                 col=colName,
-                                                 .('Adjusted Residuals: Standardized from a GLM accounting for row and column effects.'))
-                            }
-                        }
-                    }
                     freqRowNo <- freqRowNo + 1
                 }
             }
         },
+
         #### Plot functions ----
         .initBarPlot = function() {
             image <- self$results$get('barplot')
@@ -1030,7 +1026,7 @@ contTablesClass <- R6::R6Class(
 
             columns
         },
-        .matrices=function(data) {
+        .matrices = function(data) {
 
             matrices <- list()
 
@@ -1083,7 +1079,7 @@ contTablesClass <- R6::R6Class(
 
             matrices
         },
-        .grid=function(data, incRows=FALSE) {
+        .grid = function(data, incRows=FALSE) {
 
             rowVarName <- self$options$rows
             layerNames <- self$options$layers
@@ -1173,7 +1169,7 @@ contTablesClass <- R6::R6Class(
                 return('')
             super$.sourcifyOption(option)
         },
-        .formula=function() {
+        .formula = function() {
             rhs <- list()
             if ( ! is.null(self$options$rows)) {
                 rhs[[1]] <- self$options$rows

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -37,7 +37,11 @@ contTablesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             yaxis = "ycounts",
             yaxisPc = "total_pc",
             xaxis = "xrows",
-            bartype = "dodge", ...) {
+            bartype = "dodge",
+            resU = FALSE,
+            resP = FALSE,
+            resS = FALSE,
+            resA = FALSE, ...) {
 
             super$initialize(
                 package="jmv",
@@ -209,6 +213,22 @@ contTablesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "dodge",
                     "stack"),
                 default="dodge")
+            private$..resU <- jmvcore::OptionBool$new(
+                "resU",
+                resU,
+                default=FALSE)
+            private$..resP <- jmvcore::OptionBool$new(
+                "resP",
+                resP,
+                default=FALSE)
+            private$..resS <- jmvcore::OptionBool$new(
+                "resS",
+                resS,
+                default=FALSE)
+            private$..resA <- jmvcore::OptionBool$new(
+                "resA",
+                resA,
+                default=FALSE)
 
             self$.addOption(private$..rows)
             self$.addOption(private$..cols)
@@ -242,6 +262,10 @@ contTablesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             self$.addOption(private$..yaxisPc)
             self$.addOption(private$..xaxis)
             self$.addOption(private$..bartype)
+            self$.addOption(private$..resU)
+            self$.addOption(private$..resP)
+            self$.addOption(private$..resS)
+            self$.addOption(private$..resA)
         }),
     active = list(
         rows = function() private$..rows$value,
@@ -275,7 +299,11 @@ contTablesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         yaxis = function() private$..yaxis$value,
         yaxisPc = function() private$..yaxisPc$value,
         xaxis = function() private$..xaxis$value,
-        bartype = function() private$..bartype$value),
+        bartype = function() private$..bartype$value,
+        resU = function() private$..resU$value,
+        resP = function() private$..resP$value,
+        resS = function() private$..resS$value,
+        resA = function() private$..resA$value),
     private = list(
         ..rows = NA,
         ..cols = NA,
@@ -308,7 +336,11 @@ contTablesOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         ..yaxis = NA,
         ..yaxisPc = NA,
         ..xaxis = NA,
-        ..bartype = NA)
+        ..bartype = NA,
+        ..resU = NA,
+        ..resP = NA,
+        ..resS = NA,
+        ..resA = NA)
 )
 
 contTablesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
@@ -322,7 +354,8 @@ contTablesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
         gamma = function() private$.items[["gamma"]],
         taub = function() private$.items[["taub"]],
         mh = function() private$.items[["mh"]],
-        barplot = function() private$.items[["barplot"]]),
+        barplot = function() private$.items[["barplot"]],
+        phoc = function() private$.items[["phoc"]]),
     private = list(),
     public=list(
         initialize=function(options) {
@@ -679,7 +712,22 @@ contTablesResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                     "yaxis",
                     "yaxisPc",
                     "xaxis",
-                    "bartype")))}))
+                    "bartype")))
+            self$add(jmvcore::Table$new(
+                options=options,
+                name="phoc",
+                title="Post-hoc (residuals)",
+                visible="(resU || resP || resS || resA)",
+                columns=list(),
+                clearWith=list(
+                    "rows",
+                    "cols",
+                    "counts",
+                    "layers",
+                    "resU",
+                    "resP",
+                    "resS",
+                    "resA")))}))
 
 contTablesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
     "contTablesBase",
@@ -806,6 +854,14 @@ contTablesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   for the bar plot y-axis.
 #' @param xaxis rows (default), or columns in bar plot X axis
 #' @param bartype stack or side by side (default), barplot type
+#' @param resU \code{TRUE} or \code{FALSE} (default), provide Unstandardized
+#'   residuals
+#' @param resP \code{TRUE} or \code{FALSE} (default), provide Pearson
+#'   residuals
+#' @param resS \code{TRUE} or \code{FALSE} (default), provide Standardized
+#'   residuals
+#' @param resA \code{TRUE} or \code{FALSE} (default), provide Adjusted
+#'   residuals
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
 #' \tabular{llllll}{
@@ -817,6 +873,7 @@ contTablesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   \code{results$taub} \tab \tab \tab \tab \tab a table of the Kendall's tau-b test results \cr
 #'   \code{results$mh} \tab \tab \tab \tab \tab a table of the Mantel-Haenszel test for trend \cr
 #'   \code{results$barplot} \tab \tab \tab \tab \tab an image \cr
+#'   \code{results$phoc} \tab \tab \tab \tab \tab a table of residuals \cr
 #' }
 #'
 #' Tables can be converted to data frames with \code{asDF} or \code{\link{as.data.frame}}. For example:
@@ -860,6 +917,10 @@ contTables <- function(
     yaxisPc = "total_pc",
     xaxis = "xrows",
     bartype = "dodge",
+    resU = FALSE,
+    resP = FALSE,
+    resS = FALSE,
+    resA = FALSE,
     formula) {
 
     if ( ! requireNamespace("jmvcore", quietly=TRUE))
@@ -944,7 +1005,11 @@ contTables <- function(
         yaxis = yaxis,
         yaxisPc = yaxisPc,
         xaxis = xaxis,
-        bartype = bartype)
+        bartype = bartype,
+        resU = resU,
+        resP = resP,
+        resS = resS,
+        resA = resA)
 
     analysis <- contTablesClass$new(
         options = options,

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -405,4 +405,36 @@ options:
       description:
           R: >
             stack or side by side (default), barplot type
+
+    - name: resU
+      title: Unstandardized residuals
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide Unstandardized residuals
+
+    - name: resP
+      title: Pearson residuals
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide Pearson residuals
+
+    - name: resS
+      title: Standardized residuals
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide Standardized residuals
+
+    - name: resA
+      title: Adjusted residuals
+      type: Bool
+      default: false
+      description:
+          R: >
+            `TRUE` or `FALSE` (default), provide Adjusted residuals
 ...

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -422,6 +422,15 @@ options:
           R: >
             `TRUE` or `FALSE` (default), provide Pearson residuals
 
+    - name: hlresP
+      title: Highlight values above
+      type: Number
+      default: 2.0
+      description:
+          R: >
+            a number (default: 2.0), highlight values in the `'postHoc'` table
+            above this value
+
     - name: resS
       title: Standardized residuals
       type: Bool
@@ -430,6 +439,15 @@ options:
           R: >
             `TRUE` or `FALSE` (default), provide Standardized residuals
 
+    - name: hlresS
+      title: Highlight values above
+      type: Number
+      default: 2.0
+      description:
+          R: >
+            a number (default: 2.0), highlight values in the `'postHoc'` table
+            above this value
+
     - name: resA
       title: Adjusted residuals
       type: Bool
@@ -437,4 +455,13 @@ options:
       description:
           R: >
             `TRUE` or `FALSE` (default), provide Adjusted residuals
+
+    - name: hlresA
+      title: Highlight values above
+      type: Number
+      default: 2.0
+      description:
+          R: >
+            a number (default: 2.0), highlight values in the `'postHoc'` table
+            above this value
 ...

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -366,3 +366,20 @@ items:
         - yaxisPc
         - xaxis
         - bartype
+
+    - name: phoc
+      title: Post-hoc (residuals)
+      type: Table
+      visible: (resU || resP || resS || resA)
+      description: a table of residuals
+      columns: [ ]
+
+      clearWith:
+        - rows
+        - cols
+        - counts
+        - layers
+        - resU
+        - resP
+        - resS
+        - resA

--- a/jamovi/conttables.r.yaml
+++ b/jamovi/conttables.r.yaml
@@ -348,6 +348,13 @@ items:
           type: number
           format: zto,pvalue
 
+    - name: postHoc
+      title: Post Hoc Tests
+      type: Table
+      visible: (resU || resP || resS || resA)
+      description: a table of post-hoc residuals
+      columns: [ ]
+
     - name: barplot
       title: Plots
       type: Image
@@ -366,20 +373,3 @@ items:
         - yaxisPc
         - xaxis
         - bartype
-
-    - name: phoc
-      title: Post-hoc (residuals)
-      type: Table
-      visible: (resU || resP || resS || resA)
-      description: a table of residuals
-      columns: [ ]
-
-      clearWith:
-        - rows
-        - cols
-        - counts
-        - layers
-        - resU
-        - resP
-        - resS
-        - resA

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -194,6 +194,27 @@ children:
                         name: pcCol
                       - type: CheckBox
                         name: pcTot
+              - type: LayoutBox
+                cell:
+                  column: 2
+                  row: 0
+                stretchFactor: 1
+                children:
+                  - type: Label
+                    label: Post-hoc
+                    fitToGrid: true
+                    cell:
+                      column: 2
+                      row: 0
+                    children:
+                      - type: CheckBox
+                        name: resU
+                      - type: CheckBox
+                        name: resP
+                      - type: CheckBox
+                        name: resS
+                      - type: CheckBox
+                        name: resA
       - type: CollapseBox
         label: Plots
         stretchFactor: 1

--- a/jamovi/conttables.u.yaml
+++ b/jamovi/conttables.u.yaml
@@ -194,27 +194,52 @@ children:
                         name: pcCol
                       - type: CheckBox
                         name: pcTot
+      - type: CollapseBox
+        label: Post Hoc Tests
+        stretchFactor: 1
+        collapsed: true
+        children:
+          - type: LayoutBox
+            margin: large
+            stretchFactor: 1
+            children:
               - type: LayoutBox
                 cell:
-                  column: 2
+                  column: 0
                   row: 0
                 stretchFactor: 1
                 children:
                   - type: Label
-                    label: Post-hoc
+                    label: Post Hoc Tests
                     fitToGrid: true
                     cell:
-                      column: 2
+                      column: 0
                       row: 0
                     children:
                       - type: CheckBox
                         name: resU
+                        children: []
                       - type: CheckBox
                         name: resP
+                        children:
+                          - type: TextBox
+                            name: hlresP
+                            format: number
+                            enable: (resP)
                       - type: CheckBox
                         name: resS
+                        children:
+                          - type: TextBox
+                            name: hlresS
+                            format: number
+                            enable: (resS)
                       - type: CheckBox
                         name: resA
+                        children:
+                          - type: TextBox
+                            name: hlresA
+                            format: number
+                            enable: (resA)
       - type: CollapseBox
         label: Plots
         stretchFactor: 1

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -31,7 +31,11 @@ testthat::test_that('All options in the contTables work (sunny)', {
         exp = TRUE,
         pcRow = TRUE,
         pcCol = TRUE,
-        pcTot = TRUE
+        pcTot = TRUE,
+        resU = TRUE,
+        resP = TRUE,
+        resS = TRUE,
+        resA = TRUE
     )
 
     # Test main contingency tables
@@ -61,6 +65,21 @@ testthat::test_that('All options in the contTables work (sunny)', {
     testthat::expect_equal(c(1, 1, 1), mainTable[['.total[pcRow]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.45, 0.55, 1), mainTable[['.total[pcCol]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.45, 0.55, 1), mainTable[['.total[pcTot]']], tolerance = 1e-3)
+
+    # Test residuals phoc tables
+    upsaPhTab <- r$phoc$asDF
+    testthat::expect_equal(c('Unstandardized', 'Unstandardized'), upsaPhTab[['type[resU]']])
+    testthat::expect_equal(c('Pearson', 'Pearson'), upsaPhTab[['type[resP]']])
+    testthat::expect_equal(c('Standardized', 'Standardized'), upsaPhTab[['type[resS]']])
+    testthat::expect_equal(c('Adjusted', 'Adjusted'), upsaPhTab[['type[resA]']])
+    testthat::expect_equal(c(0.0500, -0.0500), upsaPhTab[['1[resU]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0500, 0.0500), upsaPhTab[['2[resU]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0104, -0.0094), upsaPhTab[['1[resP]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0106, 0.0096), upsaPhTab[['2[resP]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0201, -0.0201), upsaPhTab[['1[resS]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0201, 0.0201), upsaPhTab[['2[resS]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0104, -0.0094), upsaPhTab[['1[resA]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0107, 0.0096), upsaPhTab[['2[resA]']], tolerance = 1e-3)
 
     # Test chi squared tests table
     chiSqTable <- r$chiSq$asDF

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -201,7 +201,7 @@ testthat::test_that("conttables works with counts", {
 
     data <- data.frame(rows = rows, cols = cols, layer = layer, counts = counts)
 
-    table <- jmv::contTables(data=data, rows="rows", cols="cols", layers="layer", counts="counts")
+    table <- jmv::contTables(data=data, rows="rows", cols="cols", layers="layer", counts="counts", resU=TRUE, resP=TRUE, resS=TRUE, resA=TRUE)
 
     freqs <- as.data.frame(table$freqs)
 

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -66,20 +66,20 @@ testthat::test_that('All options in the contTables work (sunny)', {
     testthat::expect_equal(c(0.45, 0.55, 1), mainTable[['.total[pcCol]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.45, 0.55, 1), mainTable[['.total[pcTot]']], tolerance = 1e-3)
 
-    # Test residuals phoc tables
-    upsaPhTab <- r$phoc$asDF
-    testthat::expect_equal(c('Unstandardized', 'Unstandardized'), upsaPhTab[['type[resU]']])
-    testthat::expect_equal(c('Pearson', 'Pearson'), upsaPhTab[['type[resP]']])
-    testthat::expect_equal(c('Standardized', 'Standardized'), upsaPhTab[['type[resS]']])
-    testthat::expect_equal(c('Adjusted', 'Adjusted'), upsaPhTab[['type[resA]']])
-    testthat::expect_equal(c(0.0500, -0.0500), upsaPhTab[['1[resU]']], tolerance = 1e-3)
-    testthat::expect_equal(c(-0.0500, 0.0500), upsaPhTab[['2[resU]']], tolerance = 1e-3)
-    testthat::expect_equal(c(0.0104, -0.0094), upsaPhTab[['1[resP]']], tolerance = 1e-3)
-    testthat::expect_equal(c(-0.0106, 0.0096), upsaPhTab[['2[resP]']], tolerance = 1e-3)
-    testthat::expect_equal(c(0.0201, -0.0201), upsaPhTab[['1[resS]']], tolerance = 1e-3)
-    testthat::expect_equal(c(-0.0201, 0.0201), upsaPhTab[['2[resS]']], tolerance = 1e-3)
-    testthat::expect_equal(c(0.0104, -0.0094), upsaPhTab[['1[resA]']], tolerance = 1e-3)
-    testthat::expect_equal(c(-0.0107, 0.0096), upsaPhTab[['2[resA]']], tolerance = 1e-3)
+    # Test residuals postHoc tables
+    postHoc <- r$postHoc$asDF
+    testthat::expect_equal(c('Unstandardized', 'Unstandardized'), postHoc[['type[resU]']])
+    testthat::expect_equal(c('Pearson', 'Pearson'), postHoc[['type[resP]']])
+    testthat::expect_equal(c('Standardized', 'Standardized'), postHoc[['type[resS]']])
+    testthat::expect_equal(c('Adjusted', 'Adjusted'), postHoc[['type[resA]']])
+    testthat::expect_equal(c(0.0500, -0.0500), postHoc[['1[resU]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0500, 0.0500), postHoc[['2[resU]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0104, -0.0094), postHoc[['1[resP]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0106, 0.0096), postHoc[['2[resP]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0201, -0.0201), postHoc[['1[resS]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0201, 0.0201), postHoc[['2[resS]']], tolerance = 1e-3)
+    testthat::expect_equal(c(0.0104, -0.0094), postHoc[['1[resA]']], tolerance = 1e-3)
+    testthat::expect_equal(c(-0.0107, 0.0096), postHoc[['2[resA]']], tolerance = 1e-3)
 
     # Test chi squared tests table
     chiSqTable <- r$chiSq$asDF
@@ -211,6 +211,18 @@ testthat::test_that("conttables works with counts", {
     testthat::expect_equal(0, freqs[2, '2[count]'])
     testthat::expect_equal(84, freqs[12, '1[count]'])
     testthat::expect_equal(32, freqs[12, '2[count]'])
+
+    # Test residuals postHoc tables
+    postHoc <- as.data.frame(table$postHoc)
+
+    testthat::expect_equal('Unstandardized', postHoc[4, 'type[resU]'])
+    testthat::expect_equal('Pearson', postHoc[6, 'type[resP]'])
+    testthat::expect_equal('Standardized', postHoc[1, 'type[resS]'])
+    testthat::expect_equal('Adjusted', postHoc[2, 'type[resA]'])
+    testthat::expect_equal(2.111, postHoc[4, '1[resU]'], tolerance = 1e-3)
+    testthat::expect_equal(1.113, postHoc[6, '2[resP]'], tolerance = 1e-3)
+    testthat::expect_equal(-2.422, postHoc[1, '1[resS]'], tolerance = 1e-3)
+    testthat::expect_equal(-1.758, postHoc[2, '2[resA]'], tolerance = 1e-3)
 })
 
 testthat::test_that("conttables works with global integer weights", {


### PR DESCRIPTION
## Summary of Changes

This PR introduces a dedicated **post-hoc residuals table (phoc)** to complement the contingency table analyses.
Alongside the primary frequency tables and their associated statistics, the phoc table provides a richer diagnostic layer by presenting an array of residuals at the cell level.

### Key Features:

* **New phoc table:** Adds a post-hoc overview of cell-level residuals (Unstandardized, Pearson, Standardized, and Adjusted).
* **Residual Types:**
  * **Unstandardized:** Raw differences between observed and expected counts.
  * **Pearson:** Residuals scaled by the square root of the expected values.
  * **Standardized:** Residuals further normalized to account for row and column distributions, facilitating clearer interpretation.
  * **Adjusted:** Residuals derived from a Poisson GLM, providing an additional layer of refinement by incorporating row and column effects.
* **Integration:** Computations are seamlessly integrated into the existing workflow. A chi-square test and a GLM fit are performed internally, and their results are then rendered in the phoc table.
* **Enhanced Testing:** The `testconttables.R` file has been updated with new tests, ensuring the accuracy and consistency of each residual type.

### User Benefit:

This enhancement offers a deeper analytical perspective, enabling users to pinpoint meaningful discrepancies and interpret their contingency table results with greater clarity and nuance.