### PR TITLE
linReg: improve singularity error message

### DIFF
--- a/R/linreg.b.R
+++ b/R/linreg.b.R
@@ -171,6 +171,9 @@ linRegClass <- R6::R6Class(
             if (is.null(self$options$dep) || self$nModels < 1 || length(self$options$blocks[[1]]) == 0)
                 return()
 
+            if (any(private$.getIsAliased()))
+                setSingularityWarning(self)
+
             private$.populateModelFitTable()
             private$.populateModelCompTable()
             private$.populateAnovaTables()
@@ -316,10 +319,11 @@ linRegClass <- R6::R6Class(
 
             VIF <- list()
             for (i in seq_along(self$models)) {
-                if ( ! private$.getIsAliased()[[i]] && length(modelTerms[[i]]) > 1 )
+                if ( ! private$.getIsAliased()[[i]] && length(modelTerms[[i]]) > 1 ) {
                     VIF[[i]] <- car::vif(self$models[[i]])
-                else
-                    VIF[[i]] <- NULL
+                } else {
+                    VIF[[i]] <- c(VIF, list(NULL))
+                }
             }
 
             return(VIF)


### PR DESCRIPTION
With this commit, an warning notice is added, if one of the models in the analysis has a singularity issue. Also fixes an indexing problem that appears when a model contains aliased coefficients.

<img width="682" alt="Screenshot 2024-12-10 at 15 13 41" src="https://github.com/user-attachments/assets/1bba9cbe-eec0-4123-8e25-9f487ce0a6b0">

Fixes https://github.com/jamovi/jamovi/issues/1585