### PR TITLE
logRegOrd/Multi: fixed model comparison tables

### DIFF
--- a/R/logregmulti.b.R
+++ b/R/logregmulti.b.R
@@ -558,13 +558,13 @@ logRegMultiClass <- R6::R6Class(
             )
         },
         .populateModelCompTable = function() {
-            if (length(self$nModels) <= 1)
+            if (self$nModels <= 1)
                 return()
 
             table <- self$results$modelComp
             r <- self$lrtModelComparison[-1,]
 
-            for (i in seq_len(self$nModel - 1)) {
+            for (i in seq_len(self$nModels - 1)) {
                 row <- list()
                 row[["chi"]] <- r[['LR stat.']][i]
                 row[["df"]] <- r[['   Df']][i]

--- a/R/logregord.b.R
+++ b/R/logregord.b.R
@@ -473,13 +473,13 @@ logRegOrdClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             )
         },
         .populateModelCompTable = function() {
-            if (length(self$nModels) <= 1)
+            if (self$nModels <= 1)
                 return()
 
             table <- self$results$modelComp
             r <- self$lrtModelComparison[-1,]
 
-            for (i in seq_len(self$nModel - 1)) {
+            for (i in seq_len(self$nModels - 1)) {
                 row <- list()
                 row[["chi"]] <- r[['LR stat.']][i]
                 row[["df"]] <- r[['   Df']][i]

--- a/tests/testthat/testlogregmulti.R
+++ b/tests/testthat/testlogregmulti.R
@@ -201,6 +201,31 @@ testthat::test_that('All options in the logRegMulti work (sunny)', {
     )
 })
 
+testthat::test_that("Model comparison works", {
+    # GIVEN a dataset with a dependent variable and two covariates
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+    df <- data.frame(
+        dep = sample(letters[1:3], 100, replace = TRUE),
+        cov1 = rnorm(100),
+        cov2 = rnorm(100),
+        stringsAsFactors = TRUE
+    )
+
+    # WHEN a multinomial regression model is fitted in two blocks
+    r <- jmv::logRegMulti(
+        data = df,
+        dep = "dep",
+        covs = c("cov1", "cov2"),
+        blocks = list(list("cov1"), list("cov2"))
+    )
+
+    # THEN the model comparison table contains the model fit statistics
+    modelCompTable <- r$modelComp$asDF
+    testthat::expect_equal(0.0359, modelCompTable$chi, tolerance = 1e-3)
+    testthat::expect_equal(2, modelCompTable$df)
+    testthat::expect_equal(0.982, modelCompTable$p, tolerance = 1e-3)
+})
 
 testthat::test_that("Analysis works with global weights", {
     suppressWarnings(RNGversion("3.5.0"))

--- a/tests/testthat/testlogregord.R
+++ b/tests/testthat/testlogregord.R
@@ -75,6 +75,32 @@ testthat::test_that('All options in the logRegOrd work (sunny)', {
     testthat::expect_equal(c(0.401, 1.291), thresTable[['odds']], tolerance = 1e-3)
 })
 
+testthat::test_that("Model comparison works", {
+    # GIVEN a dataset with a dependent variable and two covariates
+    suppressWarnings(RNGversion("3.5.0"))
+    set.seed(1337)
+    df <- data.frame(
+        dep = sample(letters[1:3], 100, replace = TRUE),
+        cov1 = rnorm(100),
+        cov2 = rnorm(100),
+        stringsAsFactors = TRUE
+    )
+
+    # WHEN an ordinal regression model is fitted in two blocks
+    r <- jmv::logRegOrd(
+        data = df,
+        dep = "dep",
+        covs = c("cov1", "cov2"),
+        blocks = list(list("cov1"), list("cov2"))
+    )
+
+    # THEN the model comparison table contains the model fit statistics
+    modelCompTable <- r$modelComp$asDF
+    testthat::expect_equal(0.0369, modelCompTable$chi, tolerance = 1e-3)
+    testthat::expect_equal(1, modelCompTable$df)
+    testthat::expect_equal(0.848, modelCompTable$p, tolerance = 1e-3)
+})
+
 testthat::test_that("Analysis works with global weights", {
     suppressWarnings(RNGversion("3.5.0"))
     set.seed(1337)


### PR DESCRIPTION
This bug caused the model comparison tables to not get populated.