### PR TITLE
Refactor: Standardize residual titles and column for improved clarity

### DIFF
--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -602,10 +602,14 @@ contTablesClass <- R6::R6Class(
             postHoc    <- self$results$postHoc
 
             subNamesPh    <- c('[resU]', '[resP]', '[resS]', '[resA]')
-            subTitlesPh   <- c(.('Unstandardized'), .('Pearson'), .('Standardized'), .('Adjusted'))
+            subTitlesPh   <- c(.('Unstandardized Residuals'), .('Pearson Residuals'), .('Standardized Residuals'), .('Deviance Residuals'))
             visiblePh     <- c('(resU)', '(resP)', '(resS)', '(resA)')
             typesPh       <- c('number', 'number', 'number', 'number')
             formatsPh     <- c('', '', '', '')
+
+            # For post-hoc tests
+            if (self$options$get('resA'))
+                postHoc$setNote('notetodeviance', .('Deviance Residuals are adjusted residuals from a Poisson GLM.'), init=TRUE)
 
             # Add layer columns on top (if any)
             reversed <- rev(layerNames)
@@ -643,7 +647,8 @@ contTablesClass <- R6::R6Class(
             if (oneResidualSelected) {
                 selectedIndex   <- which(residualSelections)
                 singleResTitle  <- subTitlesPh[selectedIndex]
-                postHoc$setTitle(jmvcore::format("Post Hoc Test ({title} Residuals)", title=singleResTitle))
+                phTitle <- jmvcore::format('Post Hoc Test (Type: {title})', title=singleResTitle)
+                postHoc$setTitle(.(phTitle))
                 showResidualsCol <- FALSE
             } else {
                 postHoc$setTitle(.('Post Hoc Test'))
@@ -669,7 +674,7 @@ contTablesClass <- R6::R6Class(
 
                 postHoc$addColumn(
                     name  = paste0('type', subName),
-                    title = 'Residuals',
+                    title = 'Type',
                     type  = 'text',
                     visible = vPh
                 )
@@ -841,14 +846,14 @@ contTablesClass <- R6::R6Class(
                     # Check each cell and if it exceeds the threshold, add format
                     for (colIndex in seq_len(nCols)) {
 
-                        # Pearson
+                        # Pearson Residuals
                         if (!is.na(hlValueP) && self$options$resP) {
                             resValueP <- residualsP[rowNo, colIndex]
                             if (!is.na(resValueP) && abs(resValueP) > hlValueP)
                                 postHoc$addFormat(rowNo=freqRowNo, col=paste0(colIndex, "[resP]"), Cell.NEGATIVE)
                         }
 
-                        # Standardized
+                        # Standardized Residuals (adjusted Pearson)
                         if (!is.na(hlValueS) && self$options$resS) {
                             resValueS <- residualsS[rowNo, colIndex]
                             if (!is.na(resValueS) && abs(resValueS) > hlValueS) {
@@ -856,7 +861,7 @@ contTablesClass <- R6::R6Class(
                             }
                         }
 
-                        # Adjusted
+                        # Deviance Residuals
                         if (!is.na(hlValueA) && self$options$resA) {
                             resValueA <- residualsA[rowNo, colIndex]
                             if (!is.na(resValueA) && abs(resValueA) > hlValueA) {

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -602,14 +602,14 @@ contTablesClass <- R6::R6Class(
             postHoc    <- self$results$postHoc
 
             subNamesPh    <- c('[resU]', '[resP]', '[resS]', '[resA]')
-            subTitlesPh   <- c(.('Unstandardized Residuals'), .('Pearson Residuals'), .('Standardized Residuals'), .('Deviance Residuals'))
+            subTitlesPh   <- c(.('Unstandardized residuals'), .('Pearson residuals'), .('Standardized residuals'), .('Deviance residuals'))
             visiblePh     <- c('(resU)', '(resP)', '(resS)', '(resA)')
             typesPh       <- c('number', 'number', 'number', 'number')
             formatsPh     <- c('', '', '', '')
 
             # For post-hoc tests
             if (self$options$get('resA'))
-                postHoc$setNote('notetodeviance', .('Deviance residuals are adjusted residuals from a Poisson GLM.'), init=TRUE)
+                postHoc$setNote('notetodeviance', .('Deviance residuals are adjusted residuals from a Poisson GLM.'), init=FALSE)
 
             # Add layer columns on top (if any)
             reversed <- rev(layerNames)

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -647,8 +647,8 @@ contTablesClass <- R6::R6Class(
             if (oneResidualSelected) {
                 selectedIndex   <- which(residualSelections)
                 singleResTitle  <- subTitlesPh[selectedIndex]
-                phTitle <- jmvcore::format('Post Hoc Test (Type: {title})', title=singleResTitle)
-                postHoc$setTitle(.(phTitle))
+                phTitle <- jmvcore::format(.('Post Hoc Test ({title})'), title=singleResTitle)
+                postHoc$setTitle(phTitle)
                 showResidualsCol <- FALSE
             } else {
                 postHoc$setTitle(.('Post Hoc Test'))

--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -609,7 +609,7 @@ contTablesClass <- R6::R6Class(
 
             # For post-hoc tests
             if (self$options$get('resA'))
-                postHoc$setNote('notetodeviance', .('Deviance Residuals are adjusted residuals from a Poisson GLM.'), init=TRUE)
+                postHoc$setNote('notetodeviance', .('Deviance residuals are adjusted residuals from a Poisson GLM.'), init=TRUE)
 
             # Add layer columns on top (if any)
             reversed <- rev(layerNames)

--- a/R/conttables.h.R
+++ b/R/conttables.h.R
@@ -869,20 +869,20 @@ contTablesBase <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
 #'   for the bar plot y-axis.
 #' @param xaxis rows (default), or columns in bar plot X axis
 #' @param bartype stack or side by side (default), barplot type
-#' @param resU \code{TRUE} or \code{FALSE} (default), provide Unstandardized
-#'   residuals
-#' @param resP \code{TRUE} or \code{FALSE} (default), provide Pearson
-#'   residuals
-#' @param hlresP a number (default: 2.0), highlight values in the
-#'   \code{'postHoc'} table above this value
-#' @param resS \code{TRUE} or \code{FALSE} (default), provide Standardized
-#'   residuals
-#' @param hlresS a number (default: 2.0), highlight values in the
-#'   \code{'postHoc'} table above this value
-#' @param resA \code{TRUE} or \code{FALSE} (default), provide Adjusted
-#'   residuals
-#' @param hlresA a number (default: 2.0), highlight values in the
-#'   \code{'postHoc'} table above this value
+#' @param resU \code{TRUE} or \code{FALSE} (default), display unstandardized
+#'   residuals in the Post Hoc Tests table.
+#' @param resP \code{TRUE} or \code{FALSE} (default), display Pearson
+#'   residuals in the Post Hoc Tests table.
+#' @param hlresP A numeric value (default: 2.0), highlight Pearson residuals
+#'   above this threshold in the Post Hoc Tests table.
+#' @param resS \code{TRUE} or \code{FALSE} (default), display standardized
+#'   residuals (adjusted Pearson) in the Post Hoc Tests table.
+#' @param hlresS A numeric value (default: 2.0), highlight standardized
+#'   residuals above this threshold in the Post Hoc Tests table.
+#' @param resA \code{TRUE} or \code{FALSE} (default), display deviance
+#'   residuals from a Poisson GLM in the Post Hoc Tests table.
+#' @param hlresA A numeric value (default: 2.0), highlight deviance residuals
+#'   above this threshold in the Post Hoc Tests table.
 #' @param formula (optional) the formula to use, see the examples
 #' @return A results object containing:
 #' \tabular{llllll}{

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -460,5 +460,5 @@ options:
       default: 2.0
       description:
         R: >
-          A numeric value (default: 2.0), highlight deviance residuals above this threshold in the Post Hoc Tests table.
+          A numeric value (default: 2.0), highlight deviance residuals above this threshold in the post hoc tests table.
 ...

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -412,7 +412,7 @@ options:
       default: false
       description:
         R: >
-          `TRUE` or `FALSE` (default), display unstandardized residuals in the Post Hoc Tests table.
+          `TRUE` or `FALSE` (default), display unstandardized residuals in the post hoc tests table.
 
     - name: resP
       title: Pearson residuals

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -444,7 +444,7 @@ options:
       default: 2.0
       description:
         R: >
-          A numeric value (default: 2.0), highlight standardized residuals above this threshold in the Post Hoc Tests table.
+          A numeric value (default: 2.0), highlight standardized residuals above this threshold in the post hoc tests table.
 
     - name: resA
       title: Deviance Residuals (Poisson GLM)

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -428,7 +428,7 @@ options:
       default: 2.0
       description:
         R: >
-          A numeric value (default: 2.0), highlight Pearson residuals above this threshold in the Post Hoc Tests table.
+          A numeric value (default: 2.0), highlight Pearson residuals above this threshold in the post hoc tests table.
 
     - name: resS
       title: Standardized Residuals (Adjusted Pearson)

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -436,7 +436,7 @@ options:
       default: false
       description:
         R: >
-          `TRUE` or `FALSE` (default), display standardized residuals (adjusted Pearson) in the Post Hoc Tests table.
+          `TRUE` or `FALSE` (default), display standardized residuals (adjusted Pearson) in the post hoc tests table.
 
     - name: hlresS
       title: Highlight Standardized Residuals Above

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -407,7 +407,7 @@ options:
             stack or side by side (default), barplot type
 
     - name: resU
-      title: Unstandardized Residuals
+      title: Unstandardized residuals
       type: Bool
       default: false
       description:
@@ -415,7 +415,7 @@ options:
           `TRUE` or `FALSE` (default), display unstandardized residuals in the Post Hoc Tests table.
 
     - name: resP
-      title: Pearson Residuals
+      title: Pearson residuals
       type: Bool
       default: false
       description:
@@ -423,7 +423,7 @@ options:
           `TRUE` or `FALSE` (default), display Pearson residuals in the Post Hoc Tests table.
 
     - name: hlresP
-      title: Highlight Pearson Residuals Above
+      title: Highlight values above
       type: Number
       default: 2.0
       description:
@@ -431,7 +431,7 @@ options:
           A numeric value (default: 2.0), highlight Pearson residuals above this threshold in the post hoc tests table.
 
     - name: resS
-      title: Standardized Residuals (Adjusted Pearson)
+      title: Standardized residuals (adjusted Pearson)
       type: Bool
       default: false
       description:
@@ -439,7 +439,7 @@ options:
           `TRUE` or `FALSE` (default), display standardized residuals (adjusted Pearson) in the post hoc tests table.
 
     - name: hlresS
-      title: Highlight Standardized Residuals Above
+      title: Highlight values above
       type: Number
       default: 2.0
       description:
@@ -447,7 +447,7 @@ options:
           A numeric value (default: 2.0), highlight standardized residuals above this threshold in the post hoc tests table.
 
     - name: resA
-      title: Deviance Residuals (Poisson GLM)
+      title: Deviance residuals (Poisson GLM)
       type: Bool
       default: false
       description:
@@ -455,7 +455,7 @@ options:
           `TRUE` or `FALSE` (default), display deviance residuals from a Poisson GLM in the post hoc tests table.
 
     - name: hlresA
-      title: Highlight Deviance Residuals Above
+      title: Highlight values above
       type: Number
       default: 2.0
       description:

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -452,7 +452,7 @@ options:
       default: false
       description:
         R: >
-          `TRUE` or `FALSE` (default), display deviance residuals from a Poisson GLM in the Post Hoc Tests table.
+          `TRUE` or `FALSE` (default), display deviance residuals from a Poisson GLM in the post hoc tests table.
 
     - name: hlresA
       title: Highlight Deviance Residuals Above

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -407,61 +407,58 @@ options:
             stack or side by side (default), barplot type
 
     - name: resU
-      title: Unstandardized residuals
+      title: Unstandardized Residuals
       type: Bool
       default: false
       description:
-          R: >
-            `TRUE` or `FALSE` (default), provide Unstandardized residuals
+        R: >
+          `TRUE` or `FALSE` (default), display unstandardized residuals in the Post Hoc Tests table.
 
     - name: resP
-      title: Pearson residuals
+      title: Pearson Residuals
       type: Bool
       default: false
       description:
-          R: >
-            `TRUE` or `FALSE` (default), provide Pearson residuals
+        R: >
+          `TRUE` or `FALSE` (default), display Pearson residuals in the Post Hoc Tests table.
 
     - name: hlresP
-      title: Highlight values above
+      title: Highlight Pearson Residuals Above
       type: Number
       default: 2.0
       description:
-          R: >
-            a number (default: 2.0), highlight values in the `'postHoc'` table
-            above this value
+        R: >
+          A numeric value (default: 2.0), highlight Pearson residuals above this threshold in the Post Hoc Tests table.
 
     - name: resS
-      title: Standardized residuals
+      title: Standardized Residuals (Adjusted Pearson)
       type: Bool
       default: false
       description:
-          R: >
-            `TRUE` or `FALSE` (default), provide Standardized residuals
+        R: >
+          `TRUE` or `FALSE` (default), display standardized residuals (adjusted Pearson) in the Post Hoc Tests table.
 
     - name: hlresS
-      title: Highlight values above
+      title: Highlight Standardized Residuals Above
       type: Number
       default: 2.0
       description:
-          R: >
-            a number (default: 2.0), highlight values in the `'postHoc'` table
-            above this value
+        R: >
+          A numeric value (default: 2.0), highlight standardized residuals above this threshold in the Post Hoc Tests table.
 
     - name: resA
-      title: Adjusted residuals
+      title: Deviance Residuals (Poisson GLM)
       type: Bool
       default: false
       description:
-          R: >
-            `TRUE` or `FALSE` (default), provide Adjusted residuals
+        R: >
+          `TRUE` or `FALSE` (default), display deviance residuals from a Poisson GLM in the Post Hoc Tests table.
 
     - name: hlresA
-      title: Highlight values above
+      title: Highlight Deviance Residuals Above
       type: Number
       default: 2.0
       description:
-          R: >
-            a number (default: 2.0), highlight values in the `'postHoc'` table
-            above this value
+        R: >
+          A numeric value (default: 2.0), highlight deviance residuals above this threshold in the Post Hoc Tests table.
 ...

--- a/jamovi/conttables.a.yaml
+++ b/jamovi/conttables.a.yaml
@@ -420,7 +420,7 @@ options:
       default: false
       description:
         R: >
-          `TRUE` or `FALSE` (default), display Pearson residuals in the Post Hoc Tests table.
+          `TRUE` or `FALSE` (default), display Pearson residuals in the post hoc tests table.
 
     - name: hlresP
       title: Highlight values above

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -68,10 +68,10 @@ testthat::test_that('All options in the contTables work (sunny)', {
 
     # Test residuals postHoc tables
     postHoc <- r$postHoc$asDF
-    testthat::expect_equal(c('Unstandardized', 'Unstandardized'), postHoc[['type[resU]']])
-    testthat::expect_equal(c('Pearson', 'Pearson'), postHoc[['type[resP]']])
-    testthat::expect_equal(c('Standardized', 'Standardized'), postHoc[['type[resS]']])
-    testthat::expect_equal(c('Adjusted', 'Adjusted'), postHoc[['type[resA]']])
+    testthat::expect_equal(c('Unstandardized Residuals', 'Unstandardized Residuals'), postHoc[['type[resU]']])
+    testthat::expect_equal(c('Pearson Residuals', 'Pearson Residuals'), postHoc[['type[resP]']])
+    testthat::expect_equal(c('Standardized Residuals', 'Standardized Residuals'), postHoc[['type[resS]']])
+    testthat::expect_equal(c('Deviance Residuals', 'Deviance Residuals'), postHoc[['type[resA]']])
     testthat::expect_equal(c(0.0500, -0.0500), postHoc[['1[resU]']], tolerance = 1e-3)
     testthat::expect_equal(c(-0.0500, 0.0500), postHoc[['2[resU]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.0104, -0.0094), postHoc[['1[resP]']], tolerance = 1e-3)
@@ -215,10 +215,10 @@ testthat::test_that("conttables works with counts", {
     # Test residuals postHoc tables
     postHoc <- as.data.frame(table$postHoc)
 
-    testthat::expect_equal('Unstandardized', postHoc[4, 'type[resU]'])
-    testthat::expect_equal('Pearson', postHoc[6, 'type[resP]'])
-    testthat::expect_equal('Standardized', postHoc[1, 'type[resS]'])
-    testthat::expect_equal('Adjusted', postHoc[2, 'type[resA]'])
+    testthat::expect_equal('Unstandardized Residuals', postHoc[4, 'type[resU]'])
+    testthat::expect_equal('Pearson Residuals', postHoc[6, 'type[resP]'])
+    testthat::expect_equal('Standardized Residuals', postHoc[1, 'type[resS]'])
+    testthat::expect_equal('Deviance Residuals', postHoc[2, 'type[resA]'])
     testthat::expect_equal(2.111, postHoc[4, '1[resU]'], tolerance = 1e-3)
     testthat::expect_equal(1.113, postHoc[6, '2[resP]'], tolerance = 1e-3)
     testthat::expect_equal(-2.422, postHoc[1, '1[resS]'], tolerance = 1e-3)

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -68,10 +68,10 @@ testthat::test_that('All options in the contTables work (sunny)', {
 
     # Test residuals postHoc tables
     postHoc <- r$postHoc$asDF
-    testthat::expect_equal(c('Unstandardized Residuals', 'Unstandardized Residuals'), postHoc[['type[resU]']])
-    testthat::expect_equal(c('Pearson Residuals', 'Pearson Residuals'), postHoc[['type[resP]']])
-    testthat::expect_equal(c('Standardized Residuals', 'Standardized Residuals'), postHoc[['type[resS]']])
-    testthat::expect_equal(c('Deviance Residuals', 'Deviance Residuals'), postHoc[['type[resA]']])
+    testthat::expect_equal(c('Unstandardized residuals', 'Unstandardized residuals'), postHoc[['type[resU]']])
+    testthat::expect_equal(c('Pearson residuals', 'Pearson residuals'), postHoc[['type[resP]']])
+    testthat::expect_equal(c('Standardized residuals', 'Standardized residuals'), postHoc[['type[resS]']])
+    testthat::expect_equal(c('Deviance residuals', 'Deviance residuals'), postHoc[['type[resA]']])
     testthat::expect_equal(c(0.0500, -0.0500), postHoc[['1[resU]']], tolerance = 1e-3)
     testthat::expect_equal(c(-0.0500, 0.0500), postHoc[['2[resU]']], tolerance = 1e-3)
     testthat::expect_equal(c(0.0104, -0.0094), postHoc[['1[resP]']], tolerance = 1e-3)
@@ -215,10 +215,10 @@ testthat::test_that("conttables works with counts", {
     # Test residuals postHoc tables
     postHoc <- as.data.frame(table$postHoc)
 
-    testthat::expect_equal('Unstandardized Residuals', postHoc[4, 'type[resU]'])
-    testthat::expect_equal('Pearson Residuals', postHoc[6, 'type[resP]'])
-    testthat::expect_equal('Standardized Residuals', postHoc[1, 'type[resS]'])
-    testthat::expect_equal('Deviance Residuals', postHoc[2, 'type[resA]'])
+    testthat::expect_equal('Unstandardized residuals', postHoc[4, 'type[resU]'])
+    testthat::expect_equal('Pearson residuals', postHoc[6, 'type[resP]'])
+    testthat::expect_equal('Standardized residuals', postHoc[1, 'type[resS]'])
+    testthat::expect_equal('Deviance residuals', postHoc[2, 'type[resA]'])
     testthat::expect_equal(2.111, postHoc[4, '1[resU]'], tolerance = 1e-3)
     testthat::expect_equal(1.113, postHoc[6, '2[resP]'], tolerance = 1e-3)
     testthat::expect_equal(-2.422, postHoc[1, '1[resS]'], tolerance = 1e-3)


### PR DESCRIPTION
Refactor: Standardize residual titles and column for improved clarity

This PR addresses the terminology inconsistencies in residual labels within the chi-square analysis post-hoc tests, as raised in the following query:
[https://forum.jamovi.org/viewtopic.php?p=12760#p12760](url)

Specifically, this PR:

* Renames the "Residuals" column to "Type".
* Updates the residual titles to align with standard statistical terminology and R `chisq.test()` results:
    * "Pearson residuals" remain as "Pearson Residuals", consistent with the `chisq.test()` output of "residuals".
    * "Standardized residuals" are renamed to "Standardized Residuals (Adjusted Pearson)", aligning with the `chisq.test()` output of "stdres".
    * "Adjusted residuals" are renamed to "Deviance Residuals (Poisson GLM)" and a note is added to the table describing their calculation.
* Adds a note to the table explaining that "Deviance Residuals" are adjusted residuals from a Poisson GLM.

These changes aim to:

* Resolve the confusion caused by the current terminology.
* Improve the educational value of Jamovi by aligning its output with standard statistical literature and R `chisq.test()` results.
* Provide clear and accurate residual information for users.

Please review the updated labels and the added note for accuracy and clarity. Your feedback is appreciated.