### PR TITLE
Never use exact p-value for wilcox test

### DIFF
--- a/R/ttestis.b.R
+++ b/R/ttestis.b.R
@@ -257,6 +257,7 @@ ttestISClass <- R6::R6Class(
                                 x=x,
                                 y=y,
                                 alternative=Ha1,
+                                exact=FALSE,
                                 paired=FALSE,
                                 conf.int=TRUE,
                                 conf.level=confInt)
@@ -267,6 +268,7 @@ ttestISClass <- R6::R6Class(
                                 x=y,
                                 y=x,
                                 alternative=Ha2,
+                                exact=FALSE,
                                 paired=FALSE,
                                 conf.int=TRUE,
                                 conf.level=confInt)

--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -114,6 +114,7 @@ ttestOneSClass <- R6::R6Class(
                     else
                         res <- try(suppressWarnings(wilcox.test(column, mu=testValue,
                                                                 alternative=Ha,
+                                                                exact=FALSE,
                                                                 paired=FALSE,
                                                                 conf.int=TRUE,
                                                                 conf.level=cl)), silent=TRUE)

--- a/R/ttestps.b.R
+++ b/R/ttestps.b.R
@@ -74,7 +74,7 @@ ttestPSClass <- R6::R6Class(
                 }
                 else {
                     stud <- try(t.test(column1, column2, paired=TRUE, conf.level=confInt, alternative=Ha), silent=TRUE)
-                    wilc <- try(suppressWarnings(wilcox.test(column1, column2, alternative=Ha, paired=TRUE, conf.int=TRUE, conf.level=confInt)), silent=TRUE)
+                    wilc <- try(suppressWarnings(wilcox.test(column1, column2, alternative=Ha, exact=FALSE, paired=TRUE, conf.int=TRUE, conf.level=confInt)), silent=TRUE)
                 }
 
                 if ( ! isError(stud)) {

--- a/tests/testthat/testerrors.R
+++ b/tests/testthat/testerrors.R
@@ -1,41 +1,41 @@
-context('errors')
+testthat::context('errors')
 
-test_that('checkData throws error when data contains infinite values', {
+testthat::test_that('checkData throws error when data contains infinite values', {
     df <- data.frame(
         x = c(0, 3, 5, 2, Inf)
     )
     expect_error(checkData(df, checkTypes$variable_contains_inf))
 })
 
-test_that('checkData throws error when data contains NaN values', {
+testthat::test_that('checkData throws error when data contains NaN values', {
     df <- data.frame(
         x = c(0, 3, 5, 2, NaN)
     )
     expect_error(checkData(df, checkTypes$variable_contains_missing))
 })
 
-test_that('checkData throws error when data contains missing values', {
+testthat::test_that('checkData throws error when data contains missing values', {
     df <- data.frame(
         x = c(0, 3, 5, 2, NA)
     )
     expect_error(checkData(df, checkTypes$variable_contains_missing))
 })
 
-test_that('checkData throws error when data contains only missing values', {
+testthat::test_that('checkData throws error when data contains only missing values', {
     df <- data.frame(
         x = c(NA, NA, NA, NA, NA)
     )
     expect_error(checkData(df, checkTypes$variable_contains_only_missing))
 })
 
-test_that('checkData throws error when data contains only one unique numeric value', {
+testthat::test_that('checkData throws error when data contains only one unique numeric value', {
     df <- data.frame(
         x = c(1, 1, 1, 1, 1)
     )
     expect_error(checkData(df, checkTypes$variable_contains_one_unique_value))
 })
 
-test_that('checkData throws error when data contains only one unique factor level', {
+testthat::test_that('checkData throws error when data contains only one unique factor level', {
     df <- data.frame(
         x = c('A', 'A', 'A', 'A', 'A'), stringsAsFactors = TRUE
     )

--- a/tests/testthat/testttestis.R
+++ b/tests/testthat/testttestis.R
@@ -113,7 +113,7 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
     testthat::expect_equal(2, ttestTable[['stat[mann]']])
-    testthat::expect_equal(0.063, ttestTable[['p[mann]']], tolerance = 1e-3)
+    testthat::expect_equal(0.066, ttestTable[['p[mann]']], tolerance = 1e-3)
     testthat::expect_equal(-0.8, ttestTable[['es[mann]']])
 })
 
@@ -129,6 +129,6 @@ testthat::test_that('Rank biserial correlation can be negative', {
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
     testthat::expect_equal(1, ttestTable[['stat[mann]']])
-    testthat::expect_equal(0.2, ttestTable[['p[mann]']])
+    testthat::expect_equal(0.19, ttestTable[['p[mann]']], tolerance = 1e-3)
     testthat::expect_equal(-0.778, ttestTable[['es[mann]']], tolerance = 1e-3)
 })


### PR DESCRIPTION
Starting from R4.6 wilcox test will run exact p-values by default.
In previous R versions, an approximation was used when there
are more than 50 observations or ties. To have the same result
in versions we now explicitly return the approximation.