### PR TITLE
Fix failing checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     car (>= 3.0.0),
     multcomp,
     ggplot2 (>= 2.2.1),
-    PMCMR,
     emmeans (>= 1.4.2),
     vcd,
     vcdExtra,

--- a/R/anovarmnp.h.R
+++ b/R/anovarmnp.h.R
@@ -105,7 +105,6 @@ anovaRMNPResults <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 options=options,
                 name="comp",
                 title="Pairwise Comparisons (Durbin-Conover)",
-                refs="PMCMR",
                 visible="(pairs)",
                 clearWith=list(
                     "measures"),

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -990,7 +990,11 @@ descriptivesClass <- R6::R6Class(
                     next()
 
                 table <- tables$get(var)
-                freq <- freqs[[var]]
+                if (hasName(freqs, var)) {
+                    freq <- freqs[[var]]
+                } else {
+                    freq <- freqs
+                }
 
                 tableVars <- c(var, splitBy)
                 allLevels <- lapply(jmvcore::select(self$data, tableVars), levels)
@@ -1000,7 +1004,7 @@ descriptivesClass <- R6::R6Class(
                 cumsum <- 0
 
                 for (row in seq_len(nrow(grid))) {
-                    counts <- do.call("[", c(list(freq), grid[row, ]))
+                    counts <- as.numeric(do.call("[", c(list(freq), grid[row, ])))
                     cumsum <- cumsum + counts
                     pc <- counts / n
                     cumpc <- cumsum / n


### PR DESCRIPTION
These changes should take care of the failing checks on GitHub (oldrel and devel). In addition, some lines of code are copied from PMCMR::posthoc.durbin.test in order to remove the dependency on that package which is deprecated (and will be removed with the next version of R).

The GitHub action for oldrel still fails (with some install.packages issue), however, when trying the code out in a docker / rocker container with R 4.4 (=oldrel) it works without problems.