### PR TITLE
contTables: reject NA counts

### DIFF
--- a/R/conttables.b.R
+++ b/R/conttables.b.R
@@ -269,6 +269,8 @@ contTablesClass <- R6::R6Class(
                     jmvcore::reject(.('Counts may not be negative'))
                 if (any(is.infinite(data$.COUNTS)))
                     jmvcore::reject(.('Counts may not be infinite'))
+                if (any(is.na(data$.COUNTS)))
+                    jmvcore::reject(.('Counts may not contain missing values'))
             }
 
             freqs <- self$results$freqs
@@ -363,7 +365,7 @@ contTablesClass <- R6::R6Class(
                     } else
                         MCpsimul <- FALSE
 
-                    if (all(dim(mat) == 2) && all(rowSums(mat) > 0) && all(colSums(mat) > 0)) {
+                    if (isTRUE(all(dim(mat) == 2) && all(rowSums(mat) > 0) && all(colSums(mat) > 0))) {
                         dp <- private$.diffProp(mat, Ha)
                         lor <- vcd::loddsratio(mat)
                         rr <- private$.relativeRisk(mat)

--- a/tests/testthat/testconttables.R
+++ b/tests/testthat/testconttables.R
@@ -258,3 +258,19 @@ testthat::test_that("bar plots work with spaces in variable name", {
 
     testthat::expect_true(table$barplot$.render())
 })
+
+testthat::test_that("conttables rejects NA counts with a clear error", {
+    # GIVEN a 2x2 contingency table where one count value is NA
+    rows   <- factor(c("A", "B", "A", "B"), c("A", "B"))
+    cols   <- factor(c("1", "1", "2", "2"), c("1", "2"))
+    counts <- c(72, 48, 45, NA)
+    data   <- data.frame(rows = rows, cols = cols, counts = counts)
+
+    # WHEN running contTables with a counts variable containing NA
+    # THEN the analysis is rejected with a clear error message
+    testthat::expect_error(
+        jmv::contTables(data=data, rows="rows", cols="cols", counts="counts"),
+        regexp='missing values',
+        ignore.case=TRUE
+    )
+})


### PR DESCRIPTION
NA counts previously caused a cryptic R error ('missing value where TRUE/FALSE needed'). Now they are caught early and rejected with a clear message, consistent with the existing negative and infinite counts checks.