### PR TITLE
Adjust Wilcoxon tests for R 4.6 Pratt method

### DIFF
--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -107,22 +107,51 @@ ttestOneSClass <- R6::R6Class(
 
                 if (self$options$wilcoxon || self$options$mann) {
 
-                    if (is.factor(column))
+                    if (is.factor(column)) {
                         res <- createError(.('Variable is not numeric'))
-                    else if (length(column) == 0)
+                    } else if (length(column) == 0) {
                         res <- createError(.('Variable does not contain enough observations'))
-                    else
-                        res <- try(suppressWarnings(wilcox.test(column, mu=testValue,
-                                                                alternative=Ha,
-                                                                paired=FALSE,
-                                                                conf.int=TRUE,
-                                                                conf.level=cl)), silent=TRUE)
+                    } else {
+                        # Determine method based on sample size to balance precision and performance.
+                        # R 4.6+ supports exact conditional inference (Pratt's method) for data with 
+                        # ties/zeros. For N >= 50, asymptotic approximation is used for efficiency.
+                        useExact <- (n < 50)
+                      
+                        res <- try(
+                            suppressWarnings(
+                                wilcox.test(
+                                    column, 
+                                    mu=testValue,
+                                    alternative=Ha,
+                                    paired=FALSE,
+                                    conf.int=TRUE,
+                                    conf.level=cl,
+                                    exact=useExact
+                                )
+                            ), 
+                            silent=TRUE
+                        )
+                    }
+
 
                     if ( ! isError(res)) {
-
-                        nTies <- sum(column == testValue)
-                        totalRankSum <- ((n-nTies) * ((n-nTies) + 1)) / 2
-                        biSerial <- (2 * (res$statistic / totalRankSum)) - 1
+                        # The Rank Biserial Correlation (effect size) denominator must align with the 
+                        # ranking method used by wilcox.test to ensure the value remains within [-1, 1].
+                        # Pratt's method (used when exact = TRUE) retains zero-differences in the rank pool.
+                        # The asymptotic method (used when exact = FALSE) traditionally excludes zeros.
+                        if (useExact) {
+                            denom_n <- n
+                        } else {
+                            nTies <- sum(column == testValue)
+                            denom_n <- n - nTies
+                        }
+                      
+                        totalRankSum <- (denom_n * (denom_n + 1)) / 2
+                      
+                        if (totalRankSum > 0)
+                            biSerial <- (2 * (res$statistic / totalRankSum)) - 1
+                        else
+                            biSerial <- NaN
 
                         ttest$setRow(rowNo=i, list(
                             "stat[wilc]"=res$statistic,
@@ -133,9 +162,7 @@ ttestOneSClass <- R6::R6Class(
                             "es[wilc]"=biSerial,
                             "ciles[wilc]"='',
                             "ciues[wilc]"=''))
-
                     } else {
-
                         ttest$setRow(rowNo=i, list(
                             "stat[wilc]"=NaN,
                             "p[wilc]"='',

--- a/R/ttestps.b.R
+++ b/R/ttestps.b.R
@@ -74,7 +74,22 @@ ttestPSClass <- R6::R6Class(
                 }
                 else {
                     stud <- try(t.test(column1, column2, paired=TRUE, conf.level=confInt, alternative=Ha), silent=TRUE)
-                    wilc <- try(suppressWarnings(wilcox.test(column1, column2, alternative=Ha, paired=TRUE, conf.int=TRUE, conf.level=confInt)), silent=TRUE)
+
+                    # Determine method based on sample size to balance precision and performance.
+                    # R 4.6+ supports exact conditional inference (Pratt's method) for data with 
+                    # ties/zeros. For N >= 50, asymptotic approximation is used for efficiency.
+                    useExact <- (n < 50)
+                    wilc <- try(suppressWarnings(
+                        wilcox.test(
+                            column1, 
+                            column2, 
+                            alternative=Ha, 
+                            paired=TRUE, 
+                            conf.int=TRUE, 
+                            conf.level=confInt,
+                            exact=useExact
+                        )
+                    ), silent=TRUE)
                 }
 
                 if ( ! isError(stud)) {
@@ -115,8 +130,21 @@ ttestPSClass <- R6::R6Class(
 
                 if ( ! isError(wilc)) {
 
-                    totalRankSum <- ((n-nTies) * ((n-nTies) + 1)) / 2
-                    biSerial <- (2 * (wilc$statistic / totalRankSum)) - 1
+                    # The Rank Biserial Correlation (effect size) denominator must align with the 
+                    # ranking method used by wilcox.test to ensure the value remains within [-1, 1].
+                    # Pratt's method (used when exact = TRUE) retains zero-differences in the rank pool.
+                    # The asymptotic method (used when exact = FALSE) traditionally excludes zeros.
+                    if (useExact) {
+                        denom_n <- n
+                    } else {
+                        denom_n <- n - nTies
+                    }
+
+                    totalRankSum <- (denom_n * (denom_n + 1)) / 2
+                    if (totalRankSum > 0)
+                        biSerial <- (2 * (wilc$statistic / totalRankSum)) - 1
+                    else
+                        biSerial <- NaN
 
                     ttestTable$setRow(rowKey=pair, list(
                         'stat[wilc]'=wilc$statistic,

--- a/tests/testthat/testttestones.R
+++ b/tests/testthat/testttestones.R
@@ -74,9 +74,9 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
     testthat::expect_equal('dif', ttestTable[['var[wilc]']])
-    testthat::expect_equal(27, ttestTable[['stat[wilc]']])
-    testthat::expect_equal(0.234, ttestTable[['p[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(0.5, ttestTable[['es[wilc]']])
+    testthat::expect_equal(32, ttestTable[['stat[wilc]']])
+    testthat::expect_equal(0.273, ttestTable[['p[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(0.422, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })
 
 testthat::test_that('Matched rank biserial correlation works with non zero test value', {
@@ -88,5 +88,5 @@ testthat::test_that('Matched rank biserial correlation works with non zero test 
 
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
-    testthat::expect_equal(-0.0303, ttestTable[['es[wilc]']], tolerance = 1e-4)
+    testthat::expect_equal(-0.0476, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })

--- a/tests/testthat/testttestps.R
+++ b/tests/testthat/testttestps.R
@@ -95,7 +95,7 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     ttestTable <- r$ttest$asDF
     testthat::expect_equal('before', ttestTable[['var1[wilc]']], tolerance = 1e-3)
     testthat::expect_equal('after', ttestTable[['var2[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(9, ttestTable[['stat[wilc]']])
-    testthat::expect_equal(0.234, ttestTable[['p[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(-0.5, ttestTable[['es[wilc]']])
+    testthat::expect_equal(12, ttestTable[['stat[wilc]']])
+    testthat::expect_equal(0.273, ttestTable[['p[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(-0.467, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })


### PR DESCRIPTION
R 4.6.0 introduces exact conditional inference (Pratt method) for Wilcoxon tests with ties. This change updates the effect size denominator to match the test's handling of zero-differences, ensuring mathematical consistency and avoiding value shifts when toggling between exact and asymptotic methods.

Since the QA pipeline checks the test against R4.6, this should also fix the pipeline.