### PR TITLE
Reject analyses when factors have empty levels

### DIFF
--- a/R/ancova.b.R
+++ b/R/ancova.b.R
@@ -998,14 +998,9 @@ ancovaClass <- R6::R6Class(
                     )
                 }
 
-                if (any(table(self$finalData[[factorName]]) == 0)) {
-                    jmvcore::reject(
-                        .("Factor '{factorName}' contains unused levels (after removing rows with missing values)"),
-                        code=exceptions$dataError,
-                        factorName=factorName
-                    )
-                }
             }
+
+            rejectEmptyLevels(self, self$finalData, factors)
         }),
     #### Active bindings ----
     active=list(

--- a/R/anovaonew.b.R
+++ b/R/anovaonew.b.R
@@ -22,6 +22,7 @@ anovaOneWClass <- if (requireNamespace('jmvcore')) R6::R6Class(
             if (ready) {
 
                 data <- private$.cleanData()
+                private$.dataCheck(data)
                 results <- private$.compute(data)
 
                 private$.populateAnovaTable(results)
@@ -423,6 +424,9 @@ anovaOneWClass <- if (requireNamespace('jmvcore')) R6::R6Class(
                 data <- na.omit(data)
 
             return(data)
+        },
+        .dataCheck = function(data) {
+            rejectEmptyLevels(self, data, self$options$group)
         },
         .descPlotSize = function() {
 

--- a/R/utilsanova.R
+++ b/R/utilsanova.R
@@ -13,6 +13,28 @@ setSingularityWarning = function(self) {
     )
 }
 
+#' Reject the analysis if factors contain levels without observations
+#'
+#' @param self        The analysis object (for translation)
+#' @param data        The data the analysis is run on
+#' @param factorNames The names of the factors to check
+#' @keywords internal
+rejectEmptyLevels = function(self, data, factorNames) {
+    for (factorName in factorNames) {
+        counts <- table(data[[factorName]])
+        emptyLevels <- names(counts)[counts == 0]
+
+        if (length(emptyLevels) > 0) {
+            jmvcore::reject(
+                .("Factor '{factorName}' contains levels with no observations: {levels}. This can happen when all observations of a level are excluded by filters or removed due to missing values. To run the analysis, remove these unused levels from the factor."),
+                code=exceptions$dataError,
+                factorName=factorName,
+                levels=paste0("'", emptyLevels, "'", collapse=', ')
+            )
+        }
+    }
+}
+
 #' Create contrast labels (for AN(C)OVA and rmANOVA)
 #'
 #' @param levels character vector with the (names of the) factor levels

--- a/tests/testthat/testanova.R
+++ b/tests/testthat/testanova.R
@@ -407,3 +407,18 @@ testthat::test_that("Contrasts work with special characters in variable name", {
     testthat::expect_equal(contr$t, -1.091, tolerance=1e-3)
     testthat::expect_equal(contr$p, 0.307, tolerance=1e-3)
 })
+
+testthat::test_that("ANOVA rejects factors containing levels with no observations", {
+
+    # GIVEN ToothGrowth data with dose 1 filtered out but its level retained
+    dat <- datasets::ToothGrowth
+    dat$dose <- factor(dat$dose)
+    dat <- dat[dat$dose != "1", ]
+
+    # WHEN we run a Standard ANOVA on the filtered data
+    # THEN the analysis should be rejected with an informative error message
+    testthat::expect_error(
+        jmv::ANOVA(data = dat, dep = "len", factors = "dose"),
+        "Factor 'dose' contains levels with no observations: '1'"
+    )
+})

--- a/tests/testthat/testanovaonew.R
+++ b/tests/testthat/testanovaonew.R
@@ -70,3 +70,18 @@ testthat::test_that('All options in the anovaOneW work (sunny)', {
     testthat::expect_equal(37.101, postHoc$getCell(rowKey="1", "2[df]")$value, tolerance = 1e-5)
     testthat::expect_equal(5.5686e-05, postHoc$getCell(rowKey="1", "2[p]")$value, tolerance = 1e-9)
 })
+
+testthat::test_that("anovaOneW rejects group variables containing levels with no observations", {
+
+    # GIVEN ToothGrowth data with dose 1 filtered out but its level retained
+    dat <- ToothGrowth
+    dat$dose <- factor(dat$dose)
+    dat <- dat[dat$dose != 1, ]
+
+    # WHEN we run a One-Way ANOVA on the filtered data
+    # THEN the analysis should be rejected with an informative error message
+    testthat::expect_error(
+        jmv::anovaOneW(dat, deps = "len", group = "dose"),
+        "Factor 'dose' contains levels with no observations: '1'"
+    )
+})


### PR DESCRIPTION
Factor levels without observations (e.g. levels retained while all their cases are filtered out) caused one-way ANOVA to fail with an unclear error. ANOVA and ANCOVA already rejected such factors, but without naming the offending levels.

Both analyses now reject with a shared message that lists the empty levels and suggests how to resolve the issue.