### PR TITLE
descriptives: keep integer counts free of decimal places

### DIFF
--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -1000,8 +1000,10 @@ descriptivesClass <- R6::R6Class(
                 # the case values aren't available during init, so set the
                 # counts type here; only show decimals for non-integer counts
                 # (i.e. when weighted by non-integer weights)
-                if ( ! all(freq == round(freq), na.rm=TRUE))
-                    table$addColumn(name='counts', title=.('Counts'), type='number')
+                if ( ! all(freq == round(freq), na.rm=TRUE)) {
+                    countsColumn <- table$columns[['counts']]
+                    countsColumn$.__enclos_env__$private$.type <- 'number'
+                }
 
                 tableVars <- c(var, splitBy)
                 allLevels <- lapply(jmvcore::select(self$data, tableVars), levels)

--- a/R/descriptives.b.R
+++ b/R/descriptives.b.R
@@ -627,7 +627,7 @@ descriptivesClass <- R6::R6Class(
 
                 for (var in tableVars)
                     table$addColumn(name=var, title=var, type="text", combineBelow=TRUE)
-                table$addColumn(name='counts', title=.('Counts'), type='number')
+                table$addColumn(name='counts', title=.('Counts'), type='integer')
                 table$addColumn(name='pc', title=.('% of Total'), type='number', format='pc')
                 table$addColumn(name='cumpc', title=.('Cumulative %'), type='number', format='pc')
 
@@ -996,6 +996,12 @@ descriptivesClass <- R6::R6Class(
 
                 table <- tables$get(var)
                 freq <- freqs[[var]]
+
+                # the case values aren't available during init, so set the
+                # counts type here; only show decimals for non-integer counts
+                # (i.e. when weighted by non-integer weights)
+                if ( ! all(freq == round(freq), na.rm=TRUE))
+                    table$addColumn(name='counts', title=.('Counts'), type='number')
 
                 tableVars <- c(var, splitBy)
                 allLevels <- lapply(jmvcore::select(self$data, tableVars), levels)

--- a/tests/testthat/testdescriptives.R
+++ b/tests/testthat/testdescriptives.R
@@ -168,16 +168,19 @@ params <- list(
     list(
         weights = NULL,
         expected_counts = c(1, 1, 1, 1, 1),
+        expected_type = "integer",
         info = "No weights"
     ),
     list(
         weights = c(1, 2, 3, 4, 5),
         expected_counts = c(1, 2, 3, 4, 5),
+        expected_type = "integer",
         info = "Integer weights"
     ),
     list(
         weights = c(0.5, 1, 1.5, 2, 2.5),
         expected_counts = c(0.5, 1, 1.5, 2, 2.5),
+        expected_type = "number",
         info = "Non-integer weights"
     )
 )
@@ -194,6 +197,10 @@ testthat::test_that("Weighted grouped frequency table is displayed correctly", {
         # THEN the counts in the frequency table are correct
         r <- desc$frequencies[[1]]$asDF
         testthat::expect_equal(r$counts, param$expected_counts, info = param$info)
+
+        # AND the counts are only displayed as decimals for non-integer weights
+        countsType <- desc$frequencies[[1]]$getColumn("counts")$type
+        testthat::expect_equal(countsType, param$expected_type, info = param$info)
     }
 })
 


### PR DESCRIPTION
Frequency counts were typed as 'number' when weights support was added, so even unweighted or integer-weighted counts displayed decimal places. Default the column to integer and switch to number only when the counts are actually non-integer. The case values are unavailable during init, so the type is determined in the run phase.

Closes https://github.com/jamovi/jamovi/issues/1797