### PR TITLE
ci: install jmvcore from the jamovi monorepo

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::XML, any::roxygen2, github::jamovi/jmvcore
+          extra-packages: any::rcmdcheck, any::XML, any::roxygen2, github::jamovi/jamovi/jmvcore
           needs: check
 
       - name: Document


### PR DESCRIPTION
## Problem

CI fails at the dependency-resolution step with:

```
github::jamovi/jmvcore: ! GitHub HTTP error
! Unauthorized (HTTP 401).
```

The standalone `jamovi/jmvcore` repo is now private, so pak can no longer resolve it.

## Fix

`jmvcore` now lives as a module in the jamovi monorepo (`jamovi/jamovi/jmvcore`), which is public and the up-to-date source. Point the workflow's `extra-packages` at that subdirectory using pak's `user/repo/subdir` syntax.

Verified locally that `github::jamovi/jamovi/jmvcore` resolves to jmvcore 2.7.12 (satisfies `jmvcore (>= 2.4.2)`).

Note: pak fetches the full monorepo tarball to extract the `jmvcore/` subdirectory, so that step is slightly slower than the previous standalone repo.