### PR TITLE
Bugfix/wilcox cran r46 1830

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: jmv
 Type: Package
 Title: The 'jamovi' Analyses
-Version: 2.7.7
-Date: 2025-09-18
+Version: 2.8.0
+Date: 2026-06-24
 Authors@R: c(person("Ravi", "Selker", role=c("aut", "cph")),
     person("Jonathon", "Love", role=c("aut", "cre", "cph"), email="jon@thon.cc"),
     person("Damian", "Dropmann", role=c("aut", "cph")),

--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -112,11 +112,17 @@ ttestOneSClass <- R6::R6Class(
                     } else if (length(column) == 0) {
                         res <- createError(.('Variable does not contain enough observations'))
                     } else {
-                        # Determine method based on sample size to balance precision and performance.
-                        # R 4.6+ supports exact conditional inference (Pratt's method) for data with 
-                        # ties/zeros. For N >= 50, asymptotic approximation is used for efficiency.
-                        useExact <- (n < 50)
-                      
+                        # Pin R's pre-4.6 default so results don't change with the R version:
+                        # use exact inference only for small samples with no zero-differences
+                        # or ties. R 4.6.0's new default applies Pratt's exact method to
+                        # tied/zero data, which would otherwise shift the statistic, p-value
+                        # and effect size relative to earlier R.
+                        diffs <- column - testValue
+                        nonzero <- diffs[diffs != 0]
+                        useExact <- length(nonzero) < 50 &&
+                                    length(nonzero) == length(diffs) &&
+                                    ! any(duplicated(abs(nonzero)))
+
                         res <- try(
                             suppressWarnings(
                                 wilcox.test(
@@ -135,17 +141,11 @@ ttestOneSClass <- R6::R6Class(
 
 
                     if ( ! isError(res)) {
-                        # The Rank Biserial Correlation (effect size) denominator must align with the 
-                        # ranking method used by wilcox.test to ensure the value remains within [-1, 1].
-                        # Pratt's method (used when exact = TRUE) retains zero-differences in the rank pool.
-                        # The asymptotic method (used when exact = FALSE) traditionally excludes zeros.
-                        if (useExact) {
-                            denom_n <- n
-                        } else {
-                            nTies <- sum(column == testValue)
-                            denom_n <- n - nTies
-                        }
-                      
+                        # Zero-differences are dropped from the rank pool, so the rank-biserial
+                        # denominator excludes ties at the test value.
+                        nTies <- sum(column == testValue)
+                        denom_n <- n - nTies
+
                         totalRankSum <- (denom_n * (denom_n + 1)) / 2
                       
                         if (totalRankSum > 0)

--- a/R/ttestps.b.R
+++ b/R/ttestps.b.R
@@ -75,10 +75,15 @@ ttestPSClass <- R6::R6Class(
                 else {
                     stud <- try(t.test(column1, column2, paired=TRUE, conf.level=confInt, alternative=Ha), silent=TRUE)
 
-                    # Determine method based on sample size to balance precision and performance.
-                    # R 4.6+ supports exact conditional inference (Pratt's method) for data with 
-                    # ties/zeros. For N >= 50, asymptotic approximation is used for efficiency.
-                    useExact <- (n < 50)
+                    # Pin R's pre-4.6 default so results don't change with the R version:
+                    # use exact inference only for small samples with no zero-differences or
+                    # ties. R 4.6.0's new default applies Pratt's exact method to tied/zero
+                    # data, which would otherwise shift the statistic, p-value and effect size.
+                    diffs <- na.omit(column1 - column2)
+                    nonzero <- diffs[diffs != 0]
+                    useExact <- length(nonzero) < 50 &&
+                                length(nonzero) == length(diffs) &&
+                                ! any(duplicated(abs(nonzero)))
                     wilc <- try(suppressWarnings(
                         wilcox.test(
                             column1, 
@@ -130,15 +135,9 @@ ttestPSClass <- R6::R6Class(
 
                 if ( ! isError(wilc)) {
 
-                    # The Rank Biserial Correlation (effect size) denominator must align with the 
-                    # ranking method used by wilcox.test to ensure the value remains within [-1, 1].
-                    # Pratt's method (used when exact = TRUE) retains zero-differences in the rank pool.
-                    # The asymptotic method (used when exact = FALSE) traditionally excludes zeros.
-                    if (useExact) {
-                        denom_n <- n
-                    } else {
-                        denom_n <- n - nTies
-                    }
+                    # Zero-differences are dropped from the rank pool, so the rank-biserial
+                    # denominator excludes the zero-difference pairs.
+                    denom_n <- n - nTies
 
                     totalRankSum <- (denom_n * (denom_n + 1)) / 2
                     if (totalRankSum > 0)

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -1,7 +1,7 @@
 ---
 title: Analyses bundled with jamovi
 name: jmv
-version: 2.4.11
+version: 2.8.0
 jms: '1.0'
 authors:
   - Jonathon Love

--- a/tests/testthat/testttestones.R
+++ b/tests/testthat/testttestones.R
@@ -74,9 +74,9 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
     testthat::expect_equal('dif', ttestTable[['var[wilc]']])
-    testthat::expect_equal(32, ttestTable[['stat[wilc]']])
-    testthat::expect_equal(0.273, ttestTable[['p[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(0.422, ttestTable[['es[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(27, ttestTable[['stat[wilc]']])
+    testthat::expect_equal(0.234, ttestTable[['p[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(0.5, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })
 
 testthat::test_that('Matched rank biserial correlation works with non zero test value', {
@@ -88,5 +88,5 @@ testthat::test_that('Matched rank biserial correlation works with non zero test 
 
     # Test rank biserial correlation
     ttestTable <- r$ttest$asDF
-    testthat::expect_equal(-0.0476, ttestTable[['es[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(-0.0303, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })

--- a/tests/testthat/testttestps.R
+++ b/tests/testthat/testttestps.R
@@ -95,7 +95,7 @@ testthat::test_that('Matched rank biserial correlation is correct', {
     ttestTable <- r$ttest$asDF
     testthat::expect_equal('before', ttestTable[['var1[wilc]']], tolerance = 1e-3)
     testthat::expect_equal('after', ttestTable[['var2[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(12, ttestTable[['stat[wilc]']])
-    testthat::expect_equal(0.273, ttestTable[['p[wilc]']], tolerance = 1e-3)
-    testthat::expect_equal(-0.467, ttestTable[['es[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(9, ttestTable[['stat[wilc]']])
+    testthat::expect_equal(0.234, ttestTable[['p[wilc]']], tolerance = 1e-3)
+    testthat::expect_equal(-0.5, ttestTable[['es[wilc]']], tolerance = 1e-3)
 })


### PR DESCRIPTION
This reverts the Wilcox to the old behavior so that it's stable over R versions. We might decide in the future to adopt the newer way of calculating wilcox, but this way our behavior remains stable.