### PR TITLE
Drop zero-differences before the Wilcoxon test

### DIFF
--- a/R/ttestones.b.R
+++ b/R/ttestones.b.R
@@ -112,21 +112,21 @@ ttestOneSClass <- R6::R6Class(
                     } else if (length(column) == 0) {
                         res <- createError(.('Variable does not contain enough observations'))
                     } else {
-                        # Pin R's pre-4.6 default so results don't change with the R version:
-                        # use exact inference only for small samples with no zero-differences
-                        # or ties. R 4.6.0's new default applies Pratt's exact method to
-                        # tied/zero data, which would otherwise shift the statistic, p-value
-                        # and effect size relative to earlier R.
-                        diffs <- column - testValue
-                        nonzero <- diffs[diffs != 0]
+                        # R >= 4.6 keeps zero-differences in the signed-rank statistic
+                        # regardless of the 'exact' argument, which shifts the statistic,
+                        # p-value and effect size. Drop zero-differences ourselves so jmv
+                        # always reports the classic Wilcoxon test, identical across R
+                        # versions. Exact inference is used only for small samples with no
+                        # zero-differences and no ties.
+                        nonzero <- column[column != testValue]
                         useExact <- length(nonzero) < 50 &&
-                                    length(nonzero) == length(diffs) &&
-                                    ! any(duplicated(abs(nonzero)))
+                                    length(nonzero) == length(column) &&
+                                    ! any(duplicated(abs(nonzero - testValue)))
 
                         res <- try(
                             suppressWarnings(
                                 wilcox.test(
-                                    column, 
+                                    nonzero,
                                     mu=testValue,
                                     alternative=Ha,
                                     paired=FALSE,
@@ -134,7 +134,7 @@ ttestOneSClass <- R6::R6Class(
                                     conf.level=cl,
                                     exact=useExact
                                 )
-                            ), 
+                            ),
                             silent=TRUE
                         )
                     }

--- a/R/ttestps.b.R
+++ b/R/ttestps.b.R
@@ -75,22 +75,23 @@ ttestPSClass <- R6::R6Class(
                 else {
                     stud <- try(t.test(column1, column2, paired=TRUE, conf.level=confInt, alternative=Ha), silent=TRUE)
 
-                    # Pin R's pre-4.6 default so results don't change with the R version:
-                    # use exact inference only for small samples with no zero-differences or
-                    # ties. R 4.6.0's new default applies Pratt's exact method to tied/zero
-                    # data, which would otherwise shift the statistic, p-value and effect size.
-                    diffs <- na.omit(column1 - column2)
-                    nonzero <- diffs[diffs != 0]
-                    useExact <- length(nonzero) < 50 &&
-                                length(nonzero) == length(diffs) &&
-                                ! any(duplicated(abs(nonzero)))
+                    # R >= 4.6 keeps zero-differences in the signed-rank statistic regardless
+                    # of the 'exact' argument, which shifts the statistic, p-value and effect
+                    # size. Drop the zero-difference pairs ourselves so jmv always reports the
+                    # classic Wilcoxon test, identical across R versions. Exact inference is
+                    # used only for small samples with no zero-differences and no ties.
+                    diffs <- column1 - column2
+                    keep <- ! is.na(diffs) & diffs != 0
+                    useExact <- sum(keep) < 50 &&
+                                sum(keep) == sum(! is.na(diffs)) &&
+                                ! any(duplicated(abs(diffs[keep])))
                     wilc <- try(suppressWarnings(
                         wilcox.test(
-                            column1, 
-                            column2, 
-                            alternative=Ha, 
-                            paired=TRUE, 
-                            conf.int=TRUE, 
+                            column1[keep],
+                            column2[keep],
+                            alternative=Ha,
+                            paired=TRUE,
+                            conf.int=TRUE,
                             conf.level=confInt,
                             exact=useExact
                         )


### PR DESCRIPTION
The previous fix forced exact=FALSE to avoid R 4.6's Pratt method, but R-devel (4.7) keeps zero-differences in the signed-rank statistic regardless of the exact argument, so the statistic, p-value and effect size still shifted on the latest R-devel.

Drop zero-difference observations before calling wilcox.test so the statistic is computed on non-zero data only. The result is then the classic Wilcoxon test, identical across R 4.3, 4.6 and 4.7, which matches the existing test expectations.